### PR TITLE
Added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,69 @@
+; Top-most EditorConfig file.
+root = true
+
+[*]
+end_of_line = crlf
+insert_final_newline = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+dotnet_sort_system_directives_first = true
+dotnet_style_qualification_for_field = true:suggestion
+dotnet_style_qualification_for_property = true:suggestion
+dotnet_style_qualification_for_method = true:suggestion
+dotnet_style_qualification_for_event = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:none
+csharp_style_var_for_built_in_types = true:none
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:none
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = false:none
+csharp_style_expression_bodied_accessors = false:none
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = false:none
+csharp_style_conditional_delegate_call = false:suggestion
+
+csharp_space_after_cast = false
+csharp_space_in_declaration_statements 	= false
+csharp_space_before_open_square_brackets = false
+csharp_space_within_empty_square_brackets = false
+csharp_space_within_square_brackets= false
+csharp_space_after_colon_for_base_or_interface_in_type_declaration = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_colon_for_base_or_interface_in_type_declaration = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_within_method_declaration_parameter_list_parenthesis = false
+csharp_space_within_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_within_method_call_parameter_list_parenthesis = false
+csharp_space_within_method_call_empty_parameter_list_parentheses = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_within_parentheses = false
+csharp_space_around_operators = true
+csharp_wrap_block_on_single_line = true
+csharp_wrap_statements_and_member_declarations_on_same_line = false
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymouse_types = true
+csharp_new_line_within_query_expression_clauses = true


### PR DESCRIPTION
Added .editorconfig at the root of the project so it overwrite VS2017 users' formatting rules.

I attempted to respect project owner's formatting rules.

More information on https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference