### PR TITLE
Able to access property name in expression

### DIFF
--- a/LiteDB/Database/Collections/Index.cs
+++ b/LiteDB/Database/Collections/Index.cs
@@ -26,11 +26,11 @@ namespace LiteDB
         /// <param name="property">Property linq expression</param>
         /// <param name="unique">Create a unique values index?</param>
         /// <param name="expression">Create a custom expression function to be indexed</param>
-        public bool EnsureIndex<K>(Expression<Func<T, K>> property, bool unique = false, string expression = null)
+        public bool EnsureIndex<K>(Expression<Func<T, K>> property, bool unique = false, Func<T, string> expression = null)
         {
             var field = _visitor.GetField(property);
 
-            return this.EnsureIndex(field, unique, expression ?? _visitor.GetPath(property));
+            return this.EnsureIndex(field, unique, expression?.Invoke(default(T)) ?? _visitor.GetPath(property));
         }
 
         /// <summary>


### PR DESCRIPTION
This PR will enable use `nameof` for write a expression.

eg. we can write an expression like this
```cs
using (var db = new LiteRepository(new MemoryStream()))
{
    db.Database
        .GetCollection<User>()
        .EnsureIndex(x => x.Name, true, x => $"LOWER($.{nameof(x.Name)})");
    db.Insert(new User { Name = "Tom", Email = "Tom@aa.xx" });
    var tom = db.First<User>(x => x.Name == "tom");
}
```