### PR TITLE
Add SingleOrDefaultById to LiteRepository

### DIFF
--- a/LiteDB.Tests/Repository/Repository_Tests.cs
+++ b/LiteDB.Tests/Repository/Repository_Tests.cs
@@ -92,6 +92,20 @@ namespace LiteDB.Tests.Repository
 
                 Assert.AreEqual(c2.CustomerName, r3.CustomerName);
 
+                // SingleOrDefault by id 
+                try
+                {
+                    db.Query<RCustomer>().SingleById(123456);
+                    Assert.Fail("SingleById should have thrown.");
+                }
+                catch (InvalidOperationException)
+                {
+                    // Sequence contains more than one element
+                }
+                var rNull = db.Query<RCustomer>().SingleOrDefaultById(123456);
+                Assert.IsNull(rNull);
+
+
                 // get second
                 var r4 = db.Query<ROrder>()
                     .Include(x => x.Products)

--- a/LiteDB/Repository/LiteQueryable.cs
+++ b/LiteDB/Repository/LiteQueryable.cs
@@ -152,6 +152,16 @@ namespace LiteDB
             return this.ToEnumerable().Single();
         }
 
+        /// <summary>
+        /// Return entity by _id key. Throws InvalidOperationException if no document
+        /// </summary>
+        public T SingleOrDefaultById(BsonValue id)
+        {
+            _query = Query.EQ("_id", id);
+
+            return this.ToEnumerable().SingleOrDefault();
+        }
+
         #endregion
 
         #region Execute Lists

--- a/LiteDB/Repository/LiteQueryable.cs
+++ b/LiteDB/Repository/LiteQueryable.cs
@@ -153,7 +153,7 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Return entity by _id key. Throws InvalidOperationException if no document
+        /// Return entity by _id key, or default() if no document.
         /// </summary>
         public T SingleOrDefaultById(BsonValue id)
         {

--- a/LiteDB/Repository/LiteRepository.cs
+++ b/LiteDB/Repository/LiteRepository.cs
@@ -187,6 +187,14 @@ namespace LiteDB
         }
 
         /// <summary>
+        /// Search for a single instance of T by Id. Shortcut from Query.SingleOrDefaultById
+        /// </summary>
+        public T SingleOrDefaultById<T>(BsonValue id, string collectionName = null)
+        {
+            return this.Query<T>(collectionName).SingleOrDefaultById(id);
+        }
+
+        /// <summary>
         /// Execute Query[T].Where(query).ToList();
         /// </summary>
         public List<T> Fetch<T>(Query query = null, string collectionName = null)


### PR DESCRIPTION
`LiteRepository.SingleById` is super useful, but I might have cases where the entity either exists or doesn't, in which case `System.Linq.Enumerable.Single()` will throw an exception.

This adds `SingleOrDefaultById` which uses `System.Linq.Enumerable.SingleOrDefault()` instead.