### PR TITLE
Query.StringEQ / QueryStringEquals with StringComparison

### DIFF
--- a/LiteDB.Tests/Repository/Repository_Tests.cs
+++ b/LiteDB.Tests/Repository/Repository_Tests.cs
@@ -82,7 +82,8 @@ namespace LiteDB.Tests.Repository
                 // query with StringEQ
                 Assert.IsNotNull(db.Query<RCustomer>().Where(Query.EQ(nameof(RCustomer.CustomerName), "John")).FirstOrDefault());
                 Assert.IsNull(db.Query<RCustomer>().Where(Query.EQ(nameof(RCustomer.CustomerName), "john")).FirstOrDefault());
-                Assert.IsNotNull(db.Query<RCustomer>().Where(Query.StringEQ(nameof(RCustomer.CustomerName), "john", ignoreCase: true)).FirstOrDefault());
+                Assert.IsNotNull(db.Query<RCustomer>().Where(Query.StringEQ(nameof(RCustomer.CustomerName), "john", StringComparison.OrdinalIgnoreCase)).FirstOrDefault());
+                Assert.IsNull(db.Query<RCustomer>().Where(Query.StringEQ(nameof(RCustomer.CustomerName), "john", StringComparison.Ordinal)).FirstOrDefault());
 
                 // check is exists
                 var r2 = db.Query<ROrder>()

--- a/LiteDB.Tests/Repository/Repository_Tests.cs
+++ b/LiteDB.Tests/Repository/Repository_Tests.cs
@@ -79,6 +79,11 @@ namespace LiteDB.Tests.Repository
                 Assert.AreEqual(o1.Customer.CustomerName, r1.Customer.CustomerName);
                 Assert.AreEqual(o1.Customer.CustomerName, r1.Customer.CustomerName);
 
+                // query with StringEQ
+                Assert.IsNotNull(db.Query<RCustomer>().Where(Query.EQ(nameof(RCustomer.CustomerName), "John")).FirstOrDefault());
+                Assert.IsNull(db.Query<RCustomer>().Where(Query.EQ(nameof(RCustomer.CustomerName), "john")).FirstOrDefault());
+                Assert.IsNotNull(db.Query<RCustomer>().Where(Query.StringEQ(nameof(RCustomer.CustomerName), "john", ignoreCase: true)).FirstOrDefault());
+
                 // check is exists
                 var r2 = db.Query<ROrder>()
                     .Where(x => !x.Active)

--- a/LiteDB/Engine/Query/Query.cs
+++ b/LiteDB/Engine/Query/Query.cs
@@ -61,11 +61,11 @@ namespace LiteDB
             return new QueryEquals(field, value ?? BsonValue.Null);
         }
 
-        public static Query StringEQ(string field, string value, bool ignoreCase)
+        public static Query StringEQ(string field, string value, StringComparison comparison)
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return new QueryStringEquals(field, value ?? BsonValue.Null, ignoreCase);
+            return new QueryStringEquals(field, value ?? BsonValue.Null, comparison);
         }
 
         /// <summary>

--- a/LiteDB/Engine/Query/Query.cs
+++ b/LiteDB/Engine/Query/Query.cs
@@ -61,6 +61,13 @@ namespace LiteDB
             return new QueryEquals(field, value ?? BsonValue.Null);
         }
 
+        public static Query StringEQ(string field, string value, bool ignoreCase)
+        {
+            if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
+
+            return new QueryStringEquals(field, value ?? BsonValue.Null, ignoreCase);
+        }
+
         /// <summary>
         /// Returns all documents that value are less than value (&lt;)
         /// </summary>

--- a/LiteDB/Engine/Query/QueryStringEquals.cs
+++ b/LiteDB/Engine/Query/QueryStringEquals.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB
+{
+    internal class QueryStringEquals : Query
+    {
+        private BsonValue _value;
+        private bool _ignoreCase;
+
+        public QueryStringEquals(string field, BsonValue value, bool ignoreCase)
+            : base(field)
+        {
+            _value = value;
+            _ignoreCase = ignoreCase;
+        }
+
+        internal override IEnumerable<IndexNode> ExecuteIndex(IndexService indexer, CollectionIndex index)
+        {
+            var node = indexer.Find(index, _value, false, Query.Ascending);
+
+            if (node == null) yield break;
+
+            yield return node;
+
+            if (index.Unique == false)
+            {
+                // navigate using next[0] do next node - if equals, returns
+                while (!node.Next[0].IsEmpty && ((node = indexer.GetNode(node.Next[0])).Key.CompareTo(_value) == 0))
+                {
+                    if (node.IsHeadTail(index)) yield break;
+
+                    yield return node;
+                }
+            }
+        }
+
+        internal override bool FilterDocument(BsonDocument doc)
+            => Expression.Execute(doc, true).Any(x => string.Equals(_value.AsString, x.AsString, _ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal));
+
+        public override string ToString()
+            => $"{(UseFilter ? "Filter" : UseIndex ? "Seek" : "")}({Expression?.ToString() ?? Field} = {_value})";
+    }
+}

--- a/LiteDB/Engine/Query/QueryStringEquals.cs
+++ b/LiteDB/Engine/Query/QueryStringEquals.cs
@@ -7,25 +7,24 @@ namespace LiteDB
     internal class QueryStringEquals : Query
     {
         private BsonValue _value;
-        private bool _ignoreCase;
-        private StringComparison _strComp => _ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        private StringComparison _comparison;
 
-        public QueryStringEquals(string field, string value, bool ignoreCase)
+        public QueryStringEquals(string field, string value, StringComparison comparison)
             : base(field)
         {
             _value = value;
-            _ignoreCase = ignoreCase;
+            _comparison = comparison;
         }
 
         internal override IEnumerable<IndexNode> ExecuteIndex(IndexService indexer, CollectionIndex index)
         {
             return indexer
                 .FindAll(index, Query.Ascending)
-                .Where(x => x.Key.IsString && x.Key.AsString.Equals(_value, _strComp));
+                .Where(x => x.Key.IsString && x.Key.AsString.Equals(_value, _comparison));
         }
 
         internal override bool FilterDocument(BsonDocument doc)
-            => Expression.Execute(doc, true).Any(x => string.Equals(_value.AsString, x.AsString, _strComp));
+            => Expression.Execute(doc, true).Any(x => string.Equals(_value.AsString, x.AsString, _comparison));
 
         public override string ToString()
             => $"{(UseFilter ? "Filter" : UseIndex ? "Seek" : "")}({Expression?.ToString() ?? Field} = {_value})";


### PR DESCRIPTION
I have several scenarios where I need to fetch an object not by its ID, but by another field. The problem with `Query.EQ` is that it does a straight comparison, which means that strings are compared case-sensitive. Very often, the incoming value might be differently cased than the one stored, which means that I'd have to make sure to always keep them the same (e.g., calling `ToUpperInvariant` when saving and querying.

This adds a `QueryStringEquals` Query and `Query.StringEQ` method which is specifically for strings and accepts a `StringComparison`, which allows passing in e.g., `StringComparison.OrdinalIgnoreCase` for a case insensitive string comparison.