### PR TITLE
Fixed not generic type IDictionary BsonValue serialize

### DIFF
--- a/LiteDB/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Mapper/BsonMapper.Serialize.cs
@@ -102,7 +102,8 @@ namespace LiteDB
                     type = obj.GetType();
                 }
 
-                var itemType = type.IsGenericType?type.GetTypeInfo().GetGenericArguments()[1]:typeof(object);
+                var typeInfo = type.GetTypeInfo();
+                var itemType = typeInfo.IsGenericType ? typeInfo.GetGenericArguments()[1] : typeof(object);
 
                 return this.SerializeDictionary(itemType, obj as IDictionary, depth);
             }

--- a/LiteDB/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Mapper/BsonMapper.Serialize.cs
@@ -102,7 +102,7 @@ namespace LiteDB
                     type = obj.GetType();
                 }
 
-                var itemType = type.GetTypeInfo().GetGenericArguments()[1];
+                var itemType = type.IsGenericType?type.GetTypeInfo().GetGenericArguments()[1]:typeof(object);
 
                 return this.SerializeDictionary(itemType, obj as IDictionary, depth);
             }


### PR DESCRIPTION
If obj type is IDictionary but not generic type,this will cause the type.GetTypeInfo().GetGenericArguments() is empty and throw a System.IndexOutOfRangeException: Index was outside the bounds of the array.So add a generic type check.