### PR TITLE
Proposed fix for Issue #768

### DIFF
--- a/LiteDB/LiteDB.nuspec
+++ b/LiteDB/LiteDB.nuspec
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>LiteDB</id>
+    <version>4.1.2-patched</version>
+    <title>LiteDB</title>
+    <authors>Maurício David</authors>
+    <owners>Maurício David</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://raw.github.com/mbdavid/LiteDB/master/LICENSE</licenseUrl>
+    <projectUrl>https://www.litedb.org/</projectUrl>
+    <iconUrl>http://www.litedb.org/img/logo_64x64.png</iconUrl>
+    <description>LiteDB - A lightweight embedded .NET NoSQL document store in a single datafile</description>
+    <copyright>MIT</copyright>
+    <tags>database nosql embedded</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework3.5" />
+      <group targetFramework=".NETFramework4.0" />
+      <group targetFramework=".NETStandard1.3">
+        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
+        <dependency id="System.Reflection" version="4.3.0" exclude="Build,Analyzers" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.3.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Reflection" version="4.3.0" exclude="Build,Analyzers" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.3.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System" targetFramework=".NETFramework3.5, .NETFramework4.0" />
+    </frameworkAssemblies>
+  </metadata>
+	<files>
+		<file src="bin\Release\net35\LiteDB.dll" target="lib\net35" />
+		<file src="bin\Release\net35\LiteDB.xml" target="lib\net35" />
+		
+		<file src="bin\Release\net40\LiteDB.dll" target="lib\net40" />
+		<file src="bin\Release\net40\LiteDB.xml" target="lib\net40" />
+
+		<file src="bin\Release\netstandard1.3\LiteDB.dll" target="lib\netstandard1.3" />
+		<file src="bin\Release\netstandard1.3\LiteDB.xml" target="lib\netstandard1.3" />
+
+		<file src="bin\Release\netstandard2.0\LiteDB.dll" target="lib\netstandard2.0" />
+		<file src="bin\Release\netstandard2.0\LiteDB.xml" target="lib\netstandard2.0" />
+	</files>
+</package>


### PR DESCRIPTION
As I got the same error as the user in Issue #768, but with a DbRef pointing to an interface class, I made a fix that works for me. It might be beneficial as a starting point for a real fix.

The problem seems to be that the DbRef deserialization has to guess the type of the entity to load from its declared base type. If that one is an interface or abstract class, we're in trouble, because Activator.CreateInstance doesn't work on those.

There are basically two ways that I imagine will fix the problem:

1. Save the type of the DbRef target object in the reference itself, so we have a precise expression of Type and don't need to guess.
Pro: access patterns and therefore performance don't change (much).
Con: we specify the type twice, in the DbRef and in the actual entity.

2. Get the type from the DbRef target entity itself.
Pro: we specify the type only once, in the entity.
Con: there's a performance penalty getting the type from the entity, as well as an architectural breach, reaching out from BsonMapper to the database.

The proposed solution is option (1). Use it at your discretion.

Thanks for the work you're doing with LiteDB! It's great!