### PR TITLE
Made BsonMapper inheritance friendly. Derived BsonMapper provides more control over Entity Mapping

### DIFF
--- a/LiteDB.Tests/CustomMapper/Custom_Mapper_Tests.cs
+++ b/LiteDB.Tests/CustomMapper/Custom_Mapper_Tests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using LiteDB.Tests.CustomMapper.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LiteDB.Tests.CustomMapper
+{
+    [TestClass]
+    public class Custom_Mapper_Tests
+    {
+        private BsonMapper _mapper;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _mapper = new CollectionMapperClass();
+        }
+
+        private ItemCollection CreateCollection()
+        {
+            var items = new ItemCollection()
+            {
+                MyItemCollectionName = "MyCollection"
+            };
+            items.Add(new Item()
+            {
+                MyItemName = "MyItem"
+            });
+            return items;
+        }
+        [TestMethod]
+        public BsonDocument ShouldSerializeCollectionClass()
+        {
+            var items = CreateCollection();
+
+            var document = _mapper.ToDocument(items);
+            Assert.AreEqual("MyCollection", (string)document["MyItemCollectionName"]);
+
+            var array = (BsonArray)document["_items"];
+            Assert.IsNotNull(array);
+            var recoveritem = (BsonDocument)array[0];
+            Assert.AreEqual("MyItem", (string)recoveritem["MyItemName"]);
+            return document;
+        }
+
+        [TestMethod]
+        public void ShouldDeserializeCollectionClass()
+        {
+
+            var items = CreateCollection();
+            var document = _mapper.ToDocument(items);
+
+
+            var lst = (ItemCollection)_mapper.Deserialize(typeof(ItemCollection), document);
+
+            Assert.AreEqual("MyCollection", lst.MyItemCollectionName);
+            Assert.AreEqual(lst.Count, 1);
+            Assert.IsInstanceOfType(lst[0], typeof(Item));
+            Assert.AreEqual(lst[0].MyItemName,"MyItem");
+        }
+
+        [TestMethod]
+        public void ShouldInsertIntoDatabaseAndRecover()
+        {
+            var items = CreateCollection();
+            using (var repository = new LiteRepository(new MemoryStream(), _mapper))
+            {
+               var result= repository.Upsert<ItemCollection>(items);
+                Assert.IsTrue(result);
+                Assert.AreNotEqual(Guid.Empty,items.Id);
+                var lst = repository.SingleById<ItemCollection>(items.Id);
+                Assert.AreEqual("MyCollection", lst.MyItemCollectionName);
+                Assert.AreEqual(lst.Count, 1);
+                Assert.IsInstanceOfType(lst[0], typeof(Item));
+                Assert.AreEqual(lst[0].MyItemName, "MyItem");
+            }
+        }
+    }
+}

--- a/LiteDB.Tests/CustomMapper/Types/CollectionMapperClass.cs
+++ b/LiteDB.Tests/CustomMapper/Types/CollectionMapperClass.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using LiteDB.Tests.CustomMapper.Types;
+
+namespace LiteDB.Tests.CustomMapper
+{
+    public class CollectionMapperClass:BsonMapper
+    {
+        public override object Deserialize(Type type, BsonValue value)
+        {
+            if (type.GetInterfaces().Any(s => s == typeof(ICollectionClass)))
+                return DeserializeCollectionObject(type, (BsonDocument)value);
+            return base.Deserialize(type, value);
+        }
+
+        private object DeserializeCollectionObject(Type type, BsonDocument value)
+        {
+            var array = base.Deserialize(type,(BsonArray) value["_items"]);
+            DeserializeObject(type,array,value);
+            return array;
+        }
+
+        public override BsonValue Serialize(Type type, object obj, int depth)
+        {
+            if (obj is ICollectionClass)
+            {
+                return SerializeCollectionClass(type,obj,depth);
+            }
+            return base.Serialize(type, obj, depth);
+        }
+
+        private BsonDocument SerializeCollectionClass(Type type, object obj, int depth)
+        {
+            var doc = SerializeObject(type, obj, depth);
+            doc["_items"] = SerializeArray(GetListItemType(type),(IEnumerable) obj, depth);
+            return doc;
+        }
+    }
+}

--- a/LiteDB.Tests/CustomMapper/Types/ICollectionClass.cs
+++ b/LiteDB.Tests/CustomMapper/Types/ICollectionClass.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LiteDB.Tests.CustomMapper.Types
+{
+    public interface ICollectionClass
+    {
+
+    }
+}

--- a/LiteDB.Tests/CustomMapper/Types/Item.cs
+++ b/LiteDB.Tests/CustomMapper/Types/Item.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LiteDB.Tests.CustomMapper.Types
+{
+    public class Item
+    {
+        public Guid Id { get; set; }
+        public string MyItemName { get; set; }
+    }
+
+    public class ItemCollection : List<Item>, ICollectionClass
+    {
+        public Guid Id { get; set; }
+        public string MyItemCollectionName { get; set; }
+    }
+}

--- a/LiteDB/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Mapper/BsonMapper.Deserialize.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
@@ -71,8 +71,13 @@ namespace LiteDB
         };
 
         #endregion
-
-        internal object Deserialize(Type type, BsonValue value)
+        /// <summary>
+        /// Deserilize an object and it's members. It's the entry point of deserialization procedure
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public virtual object Deserialize(Type type, BsonValue value)
         {
             Func<BsonValue, object> custom;
 
@@ -187,8 +192,13 @@ namespace LiteDB
             // it's used for "public object MyInt { get; set; }"
             return value.RawValue;
         }
-
-        private object DeserializeArray(Type type, BsonArray array)
+        /// <summary>
+        /// Deserializes an array member of a class.
+        /// </summary>
+        /// <param name="type">Type of array </param>
+        /// <param name="array">BsonArray to be deserialized</param>
+        /// <returns>Deserialized Object</returns>
+        protected virtual object DeserializeArray(Type type, BsonArray array)
         {
             var arr = Array.CreateInstance(type, array.Count);
             var idx = 0;
@@ -200,8 +210,13 @@ namespace LiteDB
 
             return arr;
         }
-
-        private object DeserializeList(Type type, BsonArray value)
+        /// <summary>
+        /// Deserializes a list member of a class.
+        /// </summary>
+        /// <param name="type">Type of list </param>
+        /// <param name="array">BsonArray to be deserialized</param>
+        /// <returns>Deserialized Object</returns>
+        protected virtual object DeserializeList(Type type, BsonArray value)
         {
             var itemType = Reflection.GetListItemType(type);
             var enumerable = (IEnumerable)Reflection.CreateInstance(type);
@@ -226,8 +241,14 @@ namespace LiteDB
 
             return enumerable;
         }
-
-        private void DeserializeDictionary(Type K, Type T, IDictionary dict, BsonDocument value)
+        /// <summary>
+        /// Deserializes a Dictionary
+        /// </summary>
+        /// <param name="K">Keys</param>
+        /// <param name="T">Dictionary Value Type</param>
+        /// <param name="dict">Dictionary Object</param>
+        /// <param name="value">BsonValue to be deserialize</param>
+        protected virtual void DeserializeDictionary(Type K, Type T, IDictionary dict, BsonDocument value)
         {
             foreach (var key in value.Keys)
             {
@@ -237,8 +258,13 @@ namespace LiteDB
                 dict.Add(k, v);
             }
         }
-
-        private void DeserializeObject(Type type, object obj, BsonDocument value)
+        /// <summary>
+        /// Deserialize an Object
+        /// </summary>
+        /// <param name="type">Type of object</param>
+        /// <param name="obj">instance of deserialized object </param>
+        /// <param name="value">BsonValue for copying to instance of object</param>
+        protected virtual void DeserializeObject(Type type, object obj, BsonDocument value)
         {
             var entity = this.GetEntityMapper(type);
 

--- a/LiteDB/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Mapper/BsonMapper.Serialize.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,8 +28,14 @@ namespace LiteDB
         {
             return this.ToDocument(typeof(T), entity).AsDocument;
         }
-
-        internal BsonValue Serialize(Type type, object obj, int depth)
+        /// <summary>
+        /// Entry point on serialization procedure
+        /// </summary>
+        /// <param name="type">Type of object to be serialized</param>
+        /// <param name="obj">Instance of the object to be serialized</param>
+        /// <param name="depth">Depth of the recursive call</param>
+        /// <returns>Serialized BsonValue</returns>
+        public virtual BsonValue Serialize(Type type, object obj, int depth)
         {
             if (++depth > MAX_DEPTH) throw LiteException.DocumentMaxDepth(MAX_DEPTH, type);
 
@@ -109,7 +115,7 @@ namespace LiteDB
             // check if is a list or array
             else if (obj is IEnumerable)
             {
-                return this.SerializeArray(Reflection.GetListItemType(obj.GetType()), obj as IEnumerable, depth);
+                return this.SerializeArray(GetListItemType(obj), obj as IEnumerable, depth);
             }
             // otherwise serialize as a plain object
             else
@@ -117,8 +123,23 @@ namespace LiteDB
                 return this.SerializeObject(type, obj, depth);
             }
         }
-
-        private BsonArray SerializeArray(Type type, IEnumerable array, int depth)
+        /// <summary>
+        /// Get the Type of ListItem
+        /// </summary>
+        /// <param name="obj">Instance of List</param>
+        /// <returns>Type of ListItem</returns>
+        protected virtual Type GetListItemType(object obj)
+        {
+            return Reflection.GetListItemType(obj.GetType());
+        }
+        /// <summary>
+        /// Serializes an Array
+        /// </summary>
+        /// <param name="type">Type of <b>ListItem</b></param>
+        /// <param name="array">Instance of the array to be serialized</param>
+        /// <param name="depth">Depth of the recursive call</param>
+        /// <returns></returns>
+        protected virtual BsonArray SerializeArray(Type type, IEnumerable array, int depth)
         {
             var arr = new BsonArray();
 
@@ -129,8 +150,14 @@ namespace LiteDB
 
             return arr;
         }
-
-        private BsonDocument SerializeDictionary(Type type, IDictionary dict, int depth)
+        /// <summary>
+        /// Serialize a Dictionary
+        /// </summary>
+        /// <param name="type">Type of object to be serialized</param>
+        /// <param name="dict">Instance of the dictionary to be serialized</param>
+        /// <param name="depth">Depth of the recursive call</param>
+        /// <returns></returns>
+        protected virtual BsonDocument SerializeDictionary(Type type, IDictionary dict, int depth)
         {
             var o = new BsonDocument();
 
@@ -143,8 +170,14 @@ namespace LiteDB
 
             return o;
         }
-
-        private BsonDocument SerializeObject(Type type, object obj, int depth)
+        /// <summary>
+        /// Serializes a class object
+        /// </summary>
+        /// <param name="type">Type of object to be serialized</param>
+        /// <param name="obj">Instance of the object to be serialized</param>
+        /// <param name="depth">Depth of the recursive call</param>
+        /// <returns></returns>
+        protected virtual BsonDocument SerializeObject(Type type, object obj, int depth)
         {
             var o = new BsonDocument();
             var t = obj.GetType();


### PR DESCRIPTION
Just changed the accessibility of private methods in BsonMapper to 'protected virtual' so that they could be used in derived classes.

Added an Example use case for custom bson mapper in Tests.

I could only think of this solution for my issue mentioned in:
https://github.com/mbdavid/LiteDB/issues/1211

Hope this solution would help other users as well.

Regards,
Gunpal Jain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Custom data mappers can now tailor serialization and deserialization for specialized collection and object types.
  - Mapping behavior can be extended for arrays, lists, dictionaries, and nested objects.
  - Custom logic can determine list item types during serialization.

- **Documentation**
  - Added documentation for the newly extensible mapping operations.

- **Tests**
  - Added coverage for custom collection mapping and nested-object round trips, including database storage and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->