### PR TITLE
New `UpsertBulk` method moved to the right file.

### DIFF
--- a/LiteDB/Database/Collections/Insert.cs
+++ b/LiteDB/Database/Collections/Insert.cs
@@ -63,16 +63,6 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Implements bulk upsert of documents in a collection. Usefull when need lots of documents.
-        /// </summary>
-        public int UpsertBulk(IEnumerable<T> docs, int batchSize = 5000)
-        {
-            if (docs == null) throw new ArgumentNullException(nameof(docs));
-
-            return _engine.Value.UpsertBulk(_name, this.GetBsonDocs(docs), batchSize, _autoId);
-        }
-
-        /// <summary>
         /// Convert each T document in a BsonDocument, setting autoId for each one
         /// </summary>
         private IEnumerable<BsonDocument> GetBsonDocs(IEnumerable<T> documents)

--- a/LiteDB/Database/Collections/Upsert.cs
+++ b/LiteDB/Database/Collections/Upsert.cs
@@ -27,6 +27,16 @@ namespace LiteDB
         }
 
         /// <summary>
+        /// Implements bulk upsert of documents in a collection. Usefull when need lots of documents.
+        /// </summary>
+        public int UpsertBulk(IEnumerable<T> docs, int batchSize = 5000)
+        {
+            if (docs == null) throw new ArgumentNullException(nameof(docs));
+
+            return _engine.Value.UpsertBulk(_name, this.GetBsonDocs(docs), batchSize, _autoId);
+        }
+
+        /// <summary>
         /// Insert or Update a document in this collection.
         /// </summary>
         public bool Upsert(BsonValue id, T document)

--- a/LiteDB/Engine/Engine/Insert.cs
+++ b/LiteDB/Engine/Engine/Insert.cs
@@ -62,26 +62,6 @@ namespace LiteDB
             return count;
         }
 
-
-        /// <summary>
-        /// Bulk upsert documents to a collection - use data chunks for most efficient insert
-        /// </summary>
-        public int UpsertBulk(string collection, IEnumerable<BsonDocument> docs, int batchSize = 5000, BsonType autoId = BsonType.ObjectId)
-        {
-            if (collection.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(collection));
-            if (docs == null) throw new ArgumentNullException(nameof(docs));
-            if (batchSize < 100 || batchSize > 100000) throw new ArgumentException("batchSize must be a value between 100 and 100000");
-
-            var count = 0;
-
-            foreach (var batch in docs.Batch(batchSize))
-            {
-                count += this.Upsert(collection, batch, autoId);
-            }
-
-            return count;
-        }
-
         /// <summary>
         /// Internal implementation of insert a document
         /// </summary>

--- a/LiteDB/Engine/Engine/Upsert.cs
+++ b/LiteDB/Engine/Engine/Upsert.cs
@@ -18,6 +18,25 @@ namespace LiteDB
         }
 
         /// <summary>
+        /// Bulk upsert documents to a collection - use data chunks for most efficient insert
+        /// </summary>
+        public int UpsertBulk(string collection, IEnumerable<BsonDocument> docs, int batchSize = 5000, BsonType autoId = BsonType.ObjectId)
+        {
+            if (collection.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(collection));
+            if (docs == null) throw new ArgumentNullException(nameof(docs));
+            if (batchSize < 100 || batchSize > 100000) throw new ArgumentException("batchSize must be a value between 100 and 100000");
+
+            var count = 0;
+
+            foreach (var batch in docs.Batch(batchSize))
+            {
+                count += this.Upsert(collection, batch, autoId);
+            }
+
+            return count;
+        }
+
+        /// <summary>
         /// Implement upsert command to documents in a collection. Calls update on all documents,
         /// then any documents not updated are then attempted to insert.
         /// This will have the side effect of throwing if duplicate items are attempted to be inserted.


### PR DESCRIPTION
Hey David,

This was totally my fault in the last PR that you accepted. Unfortunately, I failed to notice that I added the new `UpsertBulk` method to the `Insert.cs` files instead of `Upsert.cs` files. This PR fixes that and hopefully prevent confusion by you and other contributors later when searching for this method.

Sorry about that.