### PR TITLE
Allows string identification fields

### DIFF
--- a/LiteDB/Database/Collections/Insert.cs
+++ b/LiteDB/Database/Collections/Insert.cs
@@ -103,7 +103,8 @@ namespace LiteDB
                     (_autoId == BsonType.Guid && id.AsGuid == Guid.Empty) ||
                     (_autoId == BsonType.DateTime && id.AsDateTime == DateTime.MinValue) ||
                     (_autoId == BsonType.Int32 && id.AsInt32 == 0) ||
-                    (_autoId == BsonType.Int64 && id.AsInt64 == 0))
+                    (_autoId == BsonType.Int64 && id.AsInt64 == 0) ||
+                    (_autoId == BsonType.String && id.IsNull))
                 {
                     // in this cases, remove _id and set new value after
                     doc.Remove("_id");

--- a/LiteDB/Database/Collections/LiteCollection.cs
+++ b/LiteDB/Database/Collections/LiteCollection.cs
@@ -47,6 +47,7 @@ namespace LiteDB
                         _id.DataType == typeof(DateTime) ? BsonType.DateTime :
                         _id.DataType == typeof(Int32) ? BsonType.Int32 :
                         _id.DataType == typeof(Int64) ? BsonType.Int64 :
+                        _id.DataType == typeof(String) ? BsonType.String :
                         BsonType.Null;
                 }
             }

--- a/LiteDB/Engine/Engine/Insert.cs
+++ b/LiteDB/Engine/Engine/Insert.cs
@@ -114,14 +114,22 @@ namespace LiteDB
                     autoId == BsonType.Guid ? new BsonValue(Guid.NewGuid()) :
                     autoId == BsonType.DateTime ? new BsonValue(DateTime.Now) :
                     autoId == BsonType.Int32 ? new BsonValue((Int32)col.Sequence) :
-                    autoId == BsonType.Int64 ? new BsonValue(col.Sequence) : BsonValue.Null;
+                    autoId == BsonType.Int64 ? new BsonValue(col.Sequence) :
+                    autoId == BsonType.String ? new BsonValue(col.Sequence.ToString()) : BsonValue.Null;
             }
+
             // create bubble in sequence number if _id is bigger than current sequence
             else if(autoId == BsonType.Int32 || autoId == BsonType.Int64)
             {
                 var current = id.AsInt64;
 
-                // if current id is bigger than sequence, jump sequence to this number. Other was, do not increse sequnce
+                // if current id is bigger than sequence, jump sequence to this number. Other was, do not increase sequence
+                col.Sequence = current >= col.Sequence ? current : col.Sequence - 1;
+            }
+            // create bubble in sequence number if _id as an string is bigger than current sequence as integer
+            else if (autoId == BsonType.String && long.TryParse(id.AsString, out var current))
+            {
+                // if current id is bigger than sequence, jump sequence to this number. Other was, do not increase sequence
                 col.Sequence = current >= col.Sequence ? current : col.Sequence - 1;
             }
 


### PR DESCRIPTION
This change allows for a `string` property to act as the `_id` field similar to an `Int64` property.

This feature allows for more flexibility for identification fields especially in cases in which the Id field is not necessarily always an integer.

The only downside to this might be the fact that one can insert a bad id manually and therefore pushes the current column sequence way further. However, this is also the case for all integer identification fields as well.