### PR TITLE
Improved unsigned values support in `BsonValue`

### DIFF
--- a/LiteDB/Document/BsonValue.cs
+++ b/LiteDB/Document/BsonValue.cs
@@ -61,6 +61,10 @@ namespace LiteDB
             this.Type = BsonType.Int64;
             this.RawValue = value;
         }
+        
+        public BsonValue(UInt32 value) : this((Int64)value)
+        {
+        }
 
         public BsonValue(Double value)
         {
@@ -260,6 +264,11 @@ namespace LiteDB
             get { return this.IsNumber ? Convert.ToInt64(this.RawValue) : default(Int64); }
         }
 
+        public uint AsUInt32
+        {
+            get { return this.IsNumber ? Convert.ToUInt32(this.RawValue) : default(UInt32); }
+        }
+
         public double AsDouble
         {
             get { return this.IsNumber ? Convert.ToDouble(this.RawValue) : default(Double); }
@@ -381,6 +390,18 @@ namespace LiteDB
 
         // Int32
         public static implicit operator BsonValue(Int32 value)
+        {
+            return new BsonValue(value);
+        }
+
+        // UInt32
+        public static implicit operator UInt32(BsonValue value)
+        {
+            return (UInt32)value.RawValue;
+        }
+
+        // UInt32
+        public static implicit operator BsonValue(UInt32 value)
         {
             return new BsonValue(value);
         }

--- a/LiteDB/Document/BsonValue.cs
+++ b/LiteDB/Document/BsonValue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -63,6 +63,10 @@ namespace LiteDB
         }
         
         public BsonValue(UInt32 value) : this((Int64)value)
+        {
+        }
+
+        public BsonValue(UInt64 value) : this((Double)value)
         {
         }
 
@@ -269,6 +273,12 @@ namespace LiteDB
             get { return this.IsNumber ? Convert.ToUInt32(this.RawValue) : default(UInt32); }
         }
 
+        public ulong AsUInt64
+        {
+            get { return this.IsNumber ? Convert.ToUInt64(this.RawValue) : default(UInt64); }
+        }
+
+
         public double AsDouble
         {
             get { return this.IsNumber ? Convert.ToDouble(this.RawValue) : default(Double); }
@@ -442,16 +452,16 @@ namespace LiteDB
             return new BsonValue(value);
         }
 
-        // UInt64 (to avoid ambigous between Double-Decimal)
+        // UInt64 (to avoid ambiguous between Double-Decimal)
         public static implicit operator UInt64(BsonValue value)
         {
             return (UInt64)value.RawValue;
         }
 
-        // Decimal
+        // UInt64
         public static implicit operator BsonValue(UInt64 value)
         {
-            return new BsonValue((Double)value);
+            return new BsonValue(value);
         }
 
         // String


### PR DESCRIPTION
This PR adds support for `UInt32` values by saving them as an `Int64` value as well as improving `UInt64` support. Changes:

* Added a constructor for `BsonValue` accepting `UInt32` as an argument and saving it as an `Int64` value
* Added a `AsUInt32` property
* Implicit operators to convert from and to `UInt32`
* Added a constructor for `BsonValue` accepting `UInt64` as an argument and saving it as a `Double` value
* Added the missing `AsUInt64` property