### PR TITLE
Update BsonMapper.Serialize.cs to correct Serialize interface

### DIFF
--- a/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
@@ -176,9 +176,13 @@ namespace LiteDB
             return o;
         }
 
+        //some settings
+        bool _useInterface=true;
+        
         private BsonDocument SerializeObject(Type type, object obj, int depth)
         {
-            var t = obj.GetType();
+            //var t = obj.GetType();
+            var t = _useInterface ? type : obj.GetType();
             var doc = new BsonDocument();
             var entity = this.GetEntityMapper(t);
 


### PR DESCRIPTION
This changes will help to Serialize interfaces correct. Now it is working like this:
    public interface IItemData
    {
        bool Auto { get; set; }
        string Name { get; set; }
        int Value { get; set; }
    }

public class ItemData : IItemData
    {
        public bool Auto { get; set; }
        public string Name { get; set; }
        public int Value { get; set; }
        public double DD { get; set; } 
}
           

List<IItemData> Data = new List<IItemData>() { new ItemData(true, 87, "First", 111.111), new ItemData(false, 43, "Second", 222.222) };

 using (var db = new LiteDatabase(DBname))
                {
                    var Col = db.GetCollection<IItemData>(CollectionName);//here i can set interface type
                    Col.InsertBulk(Data);// and here i cannot set interface type and programm use type of object (BsonMapper.Serialize.cs - line 183(184))
                }
And i get doc with all 4 fields Auto, Value, Name and DD, but i need only 3 like in interface.