### PR TITLE
Include warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ LiteDB is a small, fast and lightweight .NET NoSQL embedded database.
 - Thread-safe
 - ACID with full transaction support
 - Data recovery after write failure (WAL log file)
-- Datafile encryption using DES (AES) cryptography
+- ~~Datafile encryption using DES (AES) cryptography~~ This implemention is currently not secure, DO NOT USE.
 - Map your POCO classes to `BsonDocument` using attributes or fluent mapper API
 - Store files and stream data (like GridFS in MongoDB)
 - Single data file storage (like SQLite)


### PR DESCRIPTION
Include warning that the encryption as implemented is not secure and it should not be used. the issues are summarized in this issue 
https://github.com/mbdavid/LiteDB/issues/1273

the mode / encryption algorithm needs to be AES-GCM, AES-CBC-AEAD-HMAC, or X/ChaCha20-Poly1305 to be considered secure. The other issues also need to be fixed. AES-GCM is hard to implement correctly as such its probably better to choose a different method.

As for the warning people should be aware the current encryption will not protect their data. The website should also be updated to have a warning.