### PR TITLE
Fix exception code usage

### DIFF
--- a/LiteDB/Engine/Services/SnapShot.cs
+++ b/LiteDB/Engine/Services/SnapShot.cs
@@ -342,7 +342,7 @@ namespace LiteDB.Engine
                     // checks if not exceeded data file limit size
                     var newLength = (_header.LastPageID + 1) * PAGE_SIZE;
 
-                    if (newLength > _header.Pragmas.LimitSize) throw new LiteException(0, $"Maximum data file size has been reached: {FileHelper.FormatFileSize(_header.Pragmas.LimitSize)}");
+                    if (newLength > _header.Pragmas.LimitSize) throw LiteException.FileSizeExceeded(_header.Pragmas.LimitSize);
 
                     // increase LastPageID from shared page
                     pageID = ++_header.LastPageID;


### PR DESCRIPTION
Using the correct exception code, when the data file size limit has been reached.
Currently one would have to compare the exception message to handle this situation.