### PR TITLE
Engine/MemoryCache: Stage 1 improvements (RFC #2647)

### DIFF
--- a/LiteDB/Engine/Disk/DiskService.cs
+++ b/LiteDB/Engine/Disk/DiskService.cs
@@ -34,6 +34,9 @@ namespace LiteDB.Engine
             int[] memorySegmentSizes)
         {
             _cache = new MemoryCache(memorySegmentSizes);
+            // TODO: Add engine parameter to configure cache profile selection
+            _cache.ApplyProfile(MemoryCache.CacheProfile.Desktop);
+
             _state = state;
 
 


### PR DESCRIPTION
## Summary

This PR introduces the first round of improvements for the new in-memory cache in LiteDB 5.  
Goal: make the cache more predictable, configurable, and robust under heavy concurrent load, while keeping all tests stable.

## Key changes

1. **Volatile on scalar tuning fields**
   - Marked scalar knobs like `_maxFreePages`, `_cleanupBatchSize`, `_extends` as `volatile` to improve visibility across threads.
   - Time-based fields (`_idleBeforeEvict`, `_minCleanupInterval`) remain as `TimeSpan` (structs cannot be `volatile`).

2. **Safer on-demand cleanup triggers**
   - Removed cleanup triggers from `NewPage()` and `GetWritablePage()` to avoid interfering with segment extension and `UniqueID` sequencing (fixes the failing `Cache_UniqueIDNumbering` test).
   - Cleanup still runs in the right places:
     - `GetReadablePage()` (hot read path),
     - `DiscardPage()` (when pages are freed),
     - `Clear()` (manual cleanup),
     - and when the free-list exceeds `_maxFreePages` (forced).
   - Bounded, non-reentrant cleanup (`SemaphoreSlim`) with batched eviction and idle policy.

3. **Accurate comments & readability**
   - Updated `Cleanup()` docs to reference `_cleanupBatchSize` and `_idleBeforeEvict` (instead of stale constants).
   - Small English B1/B2 comment pass; clarified eviction/cleanup intent.

4. **Profiles groundwork**
   - Added `CacheProfile { Mobile, Desktop, Server }` and `ApplyProfile(profile)`.
   - Current defaults equal the **Desktop** profile.  
   - Future work: pass the profile through an engine parameter (`// TODO` marker left in code).

## Motivation

LiteDB is often used in embedded scenarios with high concurrency and limited resources.  
These changes make cache tuning safer and clearer without adding locking overhead or altering public APIs.

## Impact

- **No breaking API changes**  
- **No behavioral regressions**: all tests pass with updated cleanup logic  
- **Performance**: negligible overhead for volatile scalars; improved stability for live-tuned reads  

## Related

- RFC: #2647
- Bug Refs: 
  - #1756
  - #2619

## Next steps

- Wire `CacheProfile` selection via engine parameter (Etapa 2).  
- Add targeted stress tests for eviction/idle behavior under extreme concurrency.  

## Checklist

- [x] Target branch: `dev-staging`  
- [x] Builds and tests pass locally  
- [x] No public API changes  
- [x] Documentation/comments updated  
- [x] Style consistent with project guidelines

## Notes for reviewers
- This work was iterated with assistance from **ChatGPT** and **Amazon Q** for code review and validation ideas.  
- The cache was tested under **heavy stress scenarios** (high concurrency + forced cleanup) and behaved as expected without leaks or corruption.
