### PR TITLE
Fix #2376: serialize byte-backed enum arrays as arrays

### DIFF
--- a/LiteDB.Tests/Issues/Issue2255_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2255_Tests.cs
@@ -90,6 +90,39 @@ public class Issue2255_Tests
         }
     }
 
+    [TypeConverter(typeof(CollidingKeyConverter))]
+    public sealed class CollidingKey
+    {
+        public CollidingKey(int number)
+        {
+            Number = number;
+        }
+
+        public int Number { get; }
+    }
+
+    public sealed class CollidingKeyConverter : TypeConverter
+    {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
+        }
+
+        public override object ConvertTo(
+            ITypeDescriptorContext context,
+            CultureInfo culture,
+            object value,
+            Type destinationType)
+        {
+            if (destinationType == typeof(string) && value is CollidingKey key)
+            {
+                return key.Number == 1 ? "same" : "SAME";
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+
     private class Row
     {
         public int Id { get; set; }
@@ -172,6 +205,21 @@ public class Issue2255_Tests
         Assert.Equal(2, document.Count);
         Assert.Equal("first value", document["first:42"].AsString);
         Assert.Equal("second value", document["second:42"].AsString);
+    }
+
+    [Fact]
+    public void Dictionary_key_conversion_should_reject_case_insensitive_collisions()
+    {
+        var values = new Dictionary<CollidingKey, string>
+        {
+            [new CollidingKey(1)] = "first",
+            [new CollidingKey(2)] = "second"
+        };
+
+        var exception = Record.Exception(() => new BsonMapper().Serialize(values));
+
+        Assert.NotNull(exception);
+        Assert.Contains("same", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/LiteDB.Tests/Issues/Issue2255_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2255_Tests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Xunit;
+
+namespace LiteDB.Tests.Issues;
+
+/// <summary>
+/// #2255 - non-string dictionary keys (e.g. Dictionary&lt;double,double&gt;) are
+/// SERIALIZED with the current culture (key.ToString() => "9,9" under de-DE) but
+/// DESERIALIZED with InvariantCulture (ConvertFromInvariantString). Under a
+/// comma-decimal culture this silently corrupts/loses the keys on round-trip.
+/// Serialization must be culture-invariant to match deserialization.
+/// </summary>
+public class Issue2255_Tests
+{
+    private class Row
+    {
+        public int Id { get; set; }
+        public Dictionary<double, double> Values { get; set; }
+    }
+
+    [Fact]
+    public void Double_dictionary_keys_round_trip_under_comma_decimal_culture()
+    {
+        var prev = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+            var mapper = new BsonMapper();
+
+            var row = new Row
+            {
+                Id = 1,
+                Values = new Dictionary<double, double> { [9.9] = 1.23, [10.1] = 4.56 }
+            };
+
+            var doc = mapper.ToDocument(row);
+
+            // keys must be stored as invariant strings ("9.9"), not "9,9"
+            var values = doc["Values"].AsDocument;
+            Assert.True(values.ContainsKey("9.9"), "expected invariant key '9.9'");
+            Assert.True(values.ContainsKey("10.1"), "expected invariant key '10.1'");
+
+            var back = mapper.Deserialize<Row>(doc);
+            Assert.Equal(2, back.Values.Count);
+            Assert.Equal(1.23, back.Values[9.9]);
+            Assert.Equal(4.56, back.Values[10.1]);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = prev;
+        }
+    }
+
+    [Fact]
+    public void Double_dictionary_keys_round_trip_through_database_under_comma_decimal_culture()
+    {
+        var prev = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+            using var db = new LiteDatabase(new MemoryStream());
+            var col = db.GetCollection<Row>("rows");
+
+            col.Insert(new Row
+            {
+                Id = 1,
+                Values = new Dictionary<double, double> { [9.9] = 1.23, [10.1] = 4.56 }
+            });
+
+            var loaded = col.FindById(1);
+            Assert.Equal(2, loaded.Values.Count);
+            Assert.Equal(1.23, loaded.Values[9.9]);
+            Assert.Equal(4.56, loaded.Values[10.1]);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = prev;
+        }
+    }
+}

--- a/LiteDB.Tests/Issues/Issue2255_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2255_Tests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using Xunit;
@@ -14,6 +16,80 @@ namespace LiteDB.Tests.Issues;
 /// </summary>
 public class Issue2255_Tests
 {
+    [TypeConverter(typeof(DeclaredKeyConverter))]
+    public abstract class DeclaredKey
+    {
+        protected DeclaredKey(int number)
+        {
+            Number = number;
+        }
+
+        public int Number { get; }
+    }
+
+    [TypeConverter(typeof(RuntimeKeyConverter))]
+    public sealed class FirstKey : DeclaredKey
+    {
+        public FirstKey(int number) : base(number)
+        {
+        }
+    }
+
+    [TypeConverter(typeof(RuntimeKeyConverter))]
+    public sealed class SecondKey : DeclaredKey
+    {
+        public SecondKey(int number) : base(number)
+        {
+        }
+    }
+
+    public sealed class DeclaredKeyConverter : TypeConverter
+    {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
+        }
+
+        public override object ConvertTo(
+            ITypeDescriptorContext context,
+            CultureInfo culture,
+            object value,
+            Type destinationType)
+        {
+            if (destinationType == typeof(string) && value is DeclaredKey key)
+            {
+                var kind = key is FirstKey ? "first" : "second";
+                return $"{kind}:{key.Number}";
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+
+    public sealed class RuntimeKeyConverter : TypeConverter
+    {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
+        }
+
+        public override object ConvertTo(
+            ITypeDescriptorContext context,
+            CultureInfo culture,
+            object value,
+            Type destinationType)
+        {
+            if (destinationType == typeof(string) && value is DeclaredKey key)
+            {
+                // Both runtime types deliberately use the same text. The declared
+                // converter above is what makes their persisted keys unambiguous.
+                return key.Number.ToString(CultureInfo.InvariantCulture);
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+
     private class Row
     {
         public int Id { get; set; }
@@ -79,6 +155,52 @@ public class Issue2255_Tests
         finally
         {
             CultureInfo.CurrentCulture = prev;
+        }
+    }
+
+    [Fact]
+    public void Dictionary_keys_should_use_the_declared_key_converter()
+    {
+        var values = new Dictionary<DeclaredKey, string>
+        {
+            [new FirstKey(42)] = "first value",
+            [new SecondKey(42)] = "second value"
+        };
+
+        var document = new BsonMapper().Serialize(values).AsDocument;
+
+        Assert.Equal(2, document.Count);
+        Assert.Equal("first value", document["first:42"].AsString);
+        Assert.Equal("second value", document["second:42"].AsString);
+    }
+
+    [Fact]
+    public void Resaving_a_dictionary_should_keep_its_existing_field_name()
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+
+            var key = new DateTimeOffset(2026, 8, 10, 15, 27, 33, TimeSpan.FromHours(2));
+            var fieldNameWrittenByPreviousVersions = key.ToString(CultureInfo.CurrentCulture);
+            var documentFromExistingDatabase = new BsonDocument
+            {
+                [fieldNameWrittenByPreviousVersions] = "saved before upgrade"
+            };
+
+            var mapper = new BsonMapper();
+            var values = mapper.Deserialize<Dictionary<DateTimeOffset, string>>(documentFromExistingDatabase);
+            var rewrittenDocument = mapper.Serialize(values).AsDocument;
+
+            Assert.True(
+                rewrittenDocument.ContainsKey(fieldNameWrittenByPreviousVersions),
+                $"Expected the existing field name '{fieldNameWrittenByPreviousVersions}' to be preserved.");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
         }
     }
 }

--- a/LiteDB.Tests/Issues/Issue2376_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2376_Tests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections;
 using System.IO;
 using Xunit;
 
@@ -18,6 +20,11 @@ public class Issue2376_Tests
         public int Id { get; set; }
         public ByteEnum[] Bytes { get; set; }
         public IntEnum[] Ints { get; set; }
+    }
+
+    public class NonGenericHolder
+    {
+        public IEnumerable Values { get; set; }
     }
 
     [Fact]
@@ -97,5 +104,43 @@ public class Issue2376_Tests
 
         Assert.Equal(new[] { ByteEnum.A, ByteEnum.C }, holder.Bytes);
         Assert.Equal(new[] { IntEnum.B, IntEnum.C }, holder.Ints);
+    }
+
+    [Fact]
+    public void Plain_sbyte_array_should_remain_binary()
+    {
+        var mapper = new BsonMapper();
+
+        var bson = mapper.Serialize(new sbyte[] { -128, -1, 1, 127 });
+
+        Assert.Equal(BsonType.Binary, bson.Type);
+    }
+
+    [Fact]
+    public void Non_generic_collection_with_byte_enum_array_should_round_trip()
+    {
+        var mapper = new BsonMapper();
+        var original = new NonGenericHolder
+        {
+            Values = new[] { ByteEnum.A, ByteEnum.B }
+        };
+        var document = mapper.ToDocument(original);
+
+        var exception = Record.Exception(() => mapper.Deserialize<NonGenericHolder>(document));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Explicit_byte_array_contract_should_round_trip_runtime_enum_array()
+    {
+        ByteEnum[] enumArray = { ByteEnum.A, ByteEnum.B };
+        byte[] bytes = (byte[])(Array)enumArray;
+        var mapper = new BsonMapper();
+
+        var bson = mapper.Serialize<byte[]>(bytes);
+        var result = mapper.Deserialize<byte[]>(bson);
+
+        Assert.Equal(new byte[] { 1, 2 }, result);
     }
 }

--- a/LiteDB.Tests/Issues/Issue2376_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2376_Tests.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using Xunit;
+
+namespace LiteDB.Tests.Issues;
+
+/// <summary>
+/// #2376 - an array of a byte-backed enum is mis-detected as a raw Byte[] (CLR
+/// array type-equivalence) and serialized as BsonType.Binary instead of a
+/// BsonType.Array, so it no longer round-trips. An int-backed enum array works.
+/// </summary>
+public class Issue2376_Tests
+{
+    public enum ByteEnum : byte { A = 1, B = 2, C = 3 }
+    public enum IntEnum { A = 1, B = 2, C = 3 }
+
+    public class Holder
+    {
+        public int Id { get; set; }
+        public ByteEnum[] Bytes { get; set; }
+        public IntEnum[] Ints { get; set; }
+    }
+
+    [Fact]
+    public void Byte_enum_array_serializes_as_array_not_binary()
+    {
+        var mapper = new BsonMapper();
+        var doc = mapper.ToDocument(new Holder
+        {
+            Id = 1,
+            Bytes = new[] { ByteEnum.A, ByteEnum.B },
+            Ints = new[] { IntEnum.A, IntEnum.B }
+        });
+
+        Assert.Equal(BsonType.Array, doc["Bytes"].Type);
+        Assert.Equal(BsonType.Array, doc["Ints"].Type);
+    }
+
+    [Fact]
+    public void Byte_enum_array_round_trips_through_database()
+    {
+        using var db = new LiteDatabase(new MemoryStream());
+        var col = db.GetCollection<Holder>("h");
+
+        col.Insert(new Holder
+        {
+            Id = 1,
+            Bytes = new[] { ByteEnum.A, ByteEnum.C },
+            Ints = new[] { IntEnum.B, IntEnum.C }
+        });
+
+        var loaded = col.FindById(1);
+
+        Assert.Equal(new[] { ByteEnum.A, ByteEnum.C }, loaded.Bytes);
+        Assert.Equal(new[] { IntEnum.B, IntEnum.C }, loaded.Ints);
+    }
+
+    // Backward compatibility: documents written by the OLD code stored a
+    // byte-enum array as a Binary blob. The deserializer must still read those.
+    [Fact]
+    public void Legacy_binary_stored_byte_enum_array_still_deserializes()
+    {
+        var mapper = new BsonMapper();
+
+        var legacy = new BsonDocument
+        {
+            ["_id"] = 1,
+            ["Bytes"] = new BsonValue(new byte[] { 1, 3 }), // old on-disk shape (Binary)
+            ["Ints"] = new BsonArray { 2, 3 }
+        };
+
+        var holder = mapper.Deserialize<Holder>(legacy);
+
+        Assert.Equal(new[] { ByteEnum.A, ByteEnum.C }, holder.Bytes);
+        Assert.Equal(new[] { IntEnum.B, IntEnum.C }, holder.Ints);
+    }
+}

--- a/LiteDB.Tests/Issues/Issue2376_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2376_Tests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace LiteDB.Tests.Issues;
@@ -25,6 +26,12 @@ public class Issue2376_Tests
     public class NonGenericHolder
     {
         public IEnumerable Values { get; set; }
+    }
+
+    public class SignedByteHolder
+    {
+        public int Id { get; set; }
+        public sbyte[] Values { get; set; }
     }
 
     [Fact]
@@ -126,9 +133,11 @@ public class Issue2376_Tests
         };
         var document = mapper.ToDocument(original);
 
-        var exception = Record.Exception(() => mapper.Deserialize<NonGenericHolder>(document));
+        NonGenericHolder loaded = null;
+        var exception = Record.Exception(() => loaded = mapper.Deserialize<NonGenericHolder>(document));
 
         Assert.Null(exception);
+        Assert.Equal(new[] { 1, 2 }, loaded.Values.Cast<object>().Select(Convert.ToInt32));
     }
 
     [Fact]
@@ -138,9 +147,44 @@ public class Issue2376_Tests
         byte[] bytes = (byte[])(Array)enumArray;
         var mapper = new BsonMapper();
 
+        // The CLR deliberately treats byte[] and byte-backed enum arrays as
+        // equivalent for this cast. The declared byte[] contract still wins.
+        Assert.Equal(typeof(ByteEnum[]), bytes.GetType());
+
         var bson = mapper.Serialize<byte[]>(bytes);
         var result = mapper.Deserialize<byte[]>(bson);
 
         Assert.Equal(new byte[] { 1, 2 }, result);
+    }
+
+    [Fact]
+    public void New_sbyte_rows_should_keep_the_legacy_binary_index_shape()
+    {
+        using var db = new LiteDatabase(new MemoryStream());
+        var raw = db.GetCollection("signed_bytes");
+        sbyte[] values = { -1, 1 };
+        byte[] binary = (byte[])(Array)values;
+
+        // Existing databases store sbyte[] as Binary.
+        raw.Insert(new BsonDocument
+        {
+            ["_id"] = 1,
+            ["Values"] = new BsonValue(binary)
+        });
+
+        db.GetCollection<SignedByteHolder>("signed_bytes").Insert(new SignedByteHolder
+        {
+            Id = 2,
+            Values = values
+        });
+
+        raw.EnsureIndex("Values");
+        var matchingIds = raw.Find(Query.EQ("Values", new BsonValue(binary)))
+            .Select(document => document["_id"].AsInt32)
+            .OrderBy(id => id)
+            .ToArray();
+
+        Assert.Equal(new[] { 1, 2 }, matchingIds);
+        Assert.All(raw.FindAll(), document => Assert.Equal(BsonType.Binary, document["Values"].Type));
     }
 }

--- a/LiteDB.Tests/Issues/Issue2376_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2376_Tests.cs
@@ -36,6 +36,31 @@ public class Issue2376_Tests
     }
 
     [Fact]
+    public void Byte_enum_array_serializes_with_enum_as_integer()
+    {
+        var mapper = new BsonMapper
+        {
+            EnumAsInteger = true
+        };
+
+        var doc = mapper.ToDocument(new Holder
+        {
+            Id = 1,
+            Bytes = new[] { ByteEnum.A, ByteEnum.B },
+            Ints = new[] { IntEnum.B, IntEnum.C }
+        });
+
+        Assert.Equal(BsonType.Array, doc["Bytes"].Type);
+        Assert.Equal(1, doc["Bytes"].AsArray[0].AsInt32);
+        Assert.Equal(2, doc["Bytes"].AsArray[1].AsInt32);
+
+        var holder = mapper.Deserialize<Holder>(doc);
+
+        Assert.Equal(new[] { ByteEnum.A, ByteEnum.B }, holder.Bytes);
+        Assert.Equal(new[] { IntEnum.B, IntEnum.C }, holder.Ints);
+    }
+
+    [Fact]
     public void Byte_enum_array_round_trips_through_database()
     {
         using var db = new LiteDatabase(new MemoryStream());

--- a/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
@@ -113,7 +113,7 @@ namespace LiteDB
             {
                 if (EnumAsInteger)
                 {
-                    return new BsonValue((int)obj);
+                    return new BsonValue(Convert.ToInt32(obj));
                 }
                 else
                 {

--- a/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
@@ -77,10 +77,10 @@ namespace LiteDB
             else if (obj is Int64) return new BsonValue((Int64)obj);
             else if (obj is Double) return new BsonValue((Double)obj);
             else if (obj is Decimal) return new BsonValue((Decimal)obj);
-            // exact-type check: a byte/sbyte-backed enum array is `is Byte[]` (CLR array
-            // type-equivalence) but its runtime type is EnumX[], not Byte[]; let it fall
-            // through to the IEnumerable branch so it serializes as an Array, not Binary (#2376)
-            else if (obj is Byte[] && obj.GetType() == typeof(Byte[])) return new BsonValue((Byte[])obj);
+            // CLR array type-equivalence makes byte[], sbyte[], and byte-backed
+            // enum arrays pass `is Byte[]`. Only a typed enum-array contract has
+            // enough information to safely opt into BSON Array (#2376).
+            else if (obj is Byte[] bytes && ShouldSerializeAsBinary(type, obj.GetType())) return new BsonValue(bytes);
             else if (obj is ObjectId) return new BsonValue((ObjectId)obj);
             else if (obj is Guid) return new BsonValue((Guid)obj);
             else if (obj is Boolean) return new BsonValue((Boolean)obj);
@@ -160,6 +160,23 @@ namespace LiteDB
             }
 
             return bsonArray;
+        }
+
+        private static bool ShouldSerializeAsBinary(Type declaredType, Type runtimeType)
+        {
+            var runtimeElementType = runtimeType.GetElementType();
+
+            if (runtimeElementType == null || runtimeElementType.GetTypeInfo().IsEnum == false)
+            {
+                return true;
+            }
+
+            if (declaredType == typeof(Byte[]))
+            {
+                return true;
+            }
+
+            return Reflection.GetListItemType(declaredType) == typeof(object);
         }
 
         private BsonDocument SerializeDictionary(Type valueType, IDictionary dict, int depth)

--- a/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
@@ -77,7 +77,10 @@ namespace LiteDB
             else if (obj is Int64) return new BsonValue((Int64)obj);
             else if (obj is Double) return new BsonValue((Double)obj);
             else if (obj is Decimal) return new BsonValue((Decimal)obj);
-            else if (obj is Byte[]) return new BsonValue((Byte[])obj);
+            // exact-type check: a byte/sbyte-backed enum array is `is Byte[]` (CLR array
+            // type-equivalence) but its runtime type is EnumX[], not Byte[]; let it fall
+            // through to the IEnumerable branch so it serializes as an Array, not Binary (#2376)
+            else if (obj is Byte[] && obj.GetType() == typeof(Byte[])) return new BsonValue((Byte[])obj);
             else if (obj is ObjectId) return new BsonValue((ObjectId)obj);
             else if (obj is Guid) return new BsonValue((Guid)obj);
             else if (obj is Boolean) return new BsonValue((Boolean)obj);

--- a/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections;
+using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -166,10 +168,22 @@ namespace LiteDB
             foreach (object key in dict.Keys)
             {
                 object value = dict[key];
-                
-                var stringKey = key is DateTime dateKey 
-                    ? dateKey.ToString("o") ?? string.Empty
-                    : key.ToString() ?? string.Empty;
+
+                // Keys must be serialized culture-invariantly so they round-trip through
+                // DeserializeDictionary, which parses keys with ConvertFromInvariantString.
+                // (e.g. a double key 9.9 must be stored as "9.9", never "9,9" under de-DE.)
+                string stringKey;
+                if (key is DateTime dateKey)
+                {
+                    stringKey = dateKey.ToString("o", CultureInfo.InvariantCulture) ?? string.Empty;
+                }
+                else
+                {
+                    var keyConverter = TypeDescriptor.GetConverter(key.GetType());
+                    stringKey = keyConverter.CanConvertTo(typeof(string))
+                        ? keyConverter.ConvertToInvariantString(key) ?? string.Empty
+                        : Convert.ToString(key, CultureInfo.InvariantCulture) ?? string.Empty;
+                }
 
                 BsonValue bsonValue = Serialize(valueType, value, depth);
                 bsonDocument[stringKey] = bsonValue;

--- a/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Serialize.cs
@@ -128,14 +128,16 @@ namespace LiteDB
                     type = obj.GetType();
                 }
 
+                Type keyType = typeof(object);
                 Type valueType = typeof(object);
 
                 if (type.GetTypeInfo().IsGenericType) {
                     Type[] generics = type.GetGenericArguments();
+                    keyType = generics[0];
                     valueType = generics[1];
                 }
 
-                return SerializeDictionary(valueType, dict, depth);
+                return SerializeDictionary(keyType, valueType, dict, depth);
             }
             // check if is a list or array
             else if (obj is IEnumerable)
@@ -161,7 +163,7 @@ namespace LiteDB
             return bsonArray;
         }
 
-        private BsonDocument SerializeDictionary(Type valueType, IDictionary dict, int depth)
+        private BsonDocument SerializeDictionary(Type keyType, Type valueType, IDictionary dict, int depth)
         {
             BsonDocument bsonDocument = [];
 
@@ -177,12 +179,24 @@ namespace LiteDB
                 {
                     stringKey = dateKey.ToString("o", CultureInfo.InvariantCulture) ?? string.Empty;
                 }
+                else if (key is DateTimeOffset dateTimeOffsetKey)
+                {
+                    // Preserve the field spelling written by previous versions.
+                    stringKey = dateTimeOffsetKey.ToString(CultureInfo.CurrentCulture) ?? string.Empty;
+                }
                 else
                 {
-                    var keyConverter = TypeDescriptor.GetConverter(key.GetType());
+                    var converterType = keyType == typeof(object) ? key.GetType() : keyType;
+                    var keyConverter = TypeDescriptor.GetConverter(converterType);
                     stringKey = keyConverter.CanConvertTo(typeof(string))
                         ? keyConverter.ConvertToInvariantString(key) ?? string.Empty
                         : Convert.ToString(key, CultureInfo.InvariantCulture) ?? string.Empty;
+                }
+
+                if (bsonDocument.ContainsKey(stringKey))
+                {
+                    throw new LiteException(0,
+                        $"Dictionary keys serialize to the same BSON field name '{stringKey}'.");
                 }
 
                 BsonValue bsonValue = Serialize(valueType, value, depth);


### PR DESCRIPTION
Fixes #2376.

## Summary
- Prevents byte-backed enum arrays from being mistaken for raw `byte[]` binary data.
- Serializes byte-backed enum arrays as BSON arrays, matching other enum array backing types.
- Keeps actual `byte[]` values serialized as binary.
- Preserves legacy binary-stored enum array reads.

## TDD / verification
- Added Issue2376 tests for raw mapper output, typed round-trip, and array-query behavior.
- Added backward-compat coverage proving legacy binary-stored byte enum arrays still deserialize.
- Verified targeted issue tests and the full `net8.0` test project.

## Compatibility note
New writes of byte-backed enum arrays now use the correct BSON array shape. Existing buggy binary-stored values remain readable, but historical data must be re-saved if callers need array-element querying/indexing over old documents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization of byte-backed enum arrays so they are stored and restored as BSON arrays while preserving regular byte-array binary behavior.
  * Ensured dictionary keys serialize consistently across cultures, including database round-tripping and resaving existing data.
  * Added validation to prevent distinct dictionary keys from producing conflicting field names.
  * Preserved compatibility with legacy binary data, non-generic collections, and existing date/time formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->