### PR TITLE
Fix #996: preserve LiteException messages without format args

### DIFF
--- a/LiteDB.Tests/Issues/Issue996_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue996_Tests.cs
@@ -1,0 +1,38 @@
+using System;
+using Xunit;
+
+namespace LiteDB.Tests.Issues
+{
+    public class Issue996_Tests
+    {
+        [Fact]
+        public void LiteException_With_Explicit_Empty_Args_Preserves_Message_With_Braces()
+        {
+            var ex = Record.Exception(() => new LiteException(0, "Field {0} is invalid", Array.Empty<object>()));
+
+            Assert.Null(ex);
+            Assert.Equal("Field {0} is invalid", new LiteException(0, "Field {0} is invalid", Array.Empty<object>()).Message);
+        }
+
+        [Fact]
+        public void LiteException_With_Inner_Exception_And_Empty_Args_Preserves_Message_With_Braces()
+        {
+            var inner = new InvalidOperationException("inner");
+
+            var ex = Record.Exception(() => new LiteException(0, inner, "Field {0} is invalid"));
+
+            Assert.Null(ex);
+            var liteException = new LiteException(0, inner, "Field {0} is invalid");
+            Assert.Same(inner, liteException.InnerException);
+            Assert.Equal("Field {0} is invalid", liteException.Message);
+        }
+
+        [Fact]
+        public void LiteException_With_Args_Still_Formats_Message()
+        {
+            var ex = new LiteException(0, "Field {0} is invalid", "Name");
+
+            Assert.Equal("Field Name is invalid", ex.Message);
+        }
+    }
+}

--- a/LiteDB/Utils/LiteException.cs
+++ b/LiteDB/Utils/LiteException.cs
@@ -78,15 +78,20 @@ namespace LiteDB
         }
 
         internal LiteException(int code, string message, params object[] args)
-            : base(string.Format(message, args))
+            : base(FormatMessage(message, args))
         {
             this.ErrorCode = code;
         }
 
-        internal LiteException (int code, Exception inner, string message, params object[] args)
-        : base (string.Format (message, args), inner)
+        internal LiteException(int code, Exception inner, string message, params object[] args)
+            : base(FormatMessage(message, args), inner)
         {
             this.ErrorCode = code;
+        }
+
+        private static string FormatMessage(string message, object[] args)
+        {
+            return args == null || args.Length == 0 ? message : string.Format(message, args);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #996.

## Summary
- Avoids calling `string.Format` when `LiteException` formatting constructors receive no arguments.
- Preserves diagnostic messages containing literal brace placeholders such as `{0}`.
- Keeps existing formatting behavior unchanged when arguments are supplied.

## TDD / verification
- Added Issue996 tests for both formatting constructors with empty args.
- Added coverage proving normal argument formatting still works.
- Verified targeted issue tests, the Issues test namespace, and the full `net8.0` test project.

## Compatibility note
No on-disk format change. This is an exception-message/runtime behavior fix.