### PR TITLE
Fix #2190: avoid duplicate id element enumeration

### DIFF
--- a/LiteDB.Tests/Issues/Issue2190_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2190_Tests.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace LiteDB.Tests.Issues
+{
+    public class Issue2190_Tests
+    {
+        [Fact]
+        public void BsonDocument_GetElements_Should_Not_Duplicate_CaseVariant_Id_Key()
+        {
+            var doc = new BsonDocument();
+            doc["_Id"] = 1;
+            doc["Played"] = 0;
+
+            Assert.Equal(2, doc.Count);
+
+            var elements = doc.GetElements().ToArray();
+
+            Assert.Equal(2, elements.Length);
+            Assert.Equal("_id", elements[0].Key);
+            Assert.Equal("Played", elements[1].Key);
+            Assert.Equal(0, elements[1].Value.AsInt32);
+        }
+
+        [Fact]
+        public void Insert_Should_Not_Corrupt_Field_Name_When_Type_Has_UnderscoreId_Property()
+        {
+            using var db = new LiteDatabase(new MemoryStream());
+            var collection = db.GetCollection<Statistic>("dos_statistic");
+
+            collection.Insert(new Statistic { _Id = 1 });
+
+            var raw = db.GetCollection("dos_statistic").FindById(1);
+
+            Assert.NotNull(raw);
+            Assert.True(raw.ContainsKey("Played"));
+            Assert.False(raw.ContainsKey("Pla"));
+            Assert.Equal(0, raw["Played"].AsInt32);
+        }
+
+        public class Statistic
+        {
+            public int _Id { get; set; }
+
+            public int Played { get; set; } = 0;
+        }
+    }
+}

--- a/LiteDB/Document/BsonDocument.cs
+++ b/LiteDB/Document/BsonDocument.cs
@@ -114,7 +114,7 @@ namespace LiteDB
                 yield return new KeyValuePair<string, BsonValue>("_id", id);
             }
 
-            foreach(var item in this.RawValue.Where(x => x.Key != "_id"))
+            foreach(var item in this.RawValue.Where(x => !x.Key.Equals("_id", StringComparison.OrdinalIgnoreCase)))
             {
                 yield return item;
             }


### PR DESCRIPTION
Fixes #2190.

## Summary
- Makes `BsonDocument.GetElements()` exclude `_id` using the same case-insensitive comparison as the backing dictionary.
- Prevents case-variant `_Id` properties from being emitted twice during serialization.
- Fixes debug-time buffer overflows and release-time field-name truncation such as `Played` becoming `Pla`.

## TDD / verification
- Added Issue2190 coverage for the raw `BsonDocument.GetElements()` duplicate element bug.
- Added end-to-end typed insert coverage for an entity with `_Id` and `Played` properties.
- Verified targeted issue tests, document tests, buffer-writer tests, and the full `net8.0` test project.

## Compatibility note
No valid on-disk format is changed. The affected documents either failed to serialize in debug builds or could be written corrupted in release builds; this prevents new corruption.