### PR TITLE
Fix #1929: deserialize System.Index values

### DIFF
--- a/LiteDB.Tests/Issues/Issue1929_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1929_Tests.cs
@@ -74,6 +74,25 @@ namespace LiteDB.Tests.Issues
         }
 
         [Fact]
+        public void Object_Type_Discriminator_Should_Still_Honor_The_Custom_Index_Constructor()
+        {
+            var mapper = new BsonMapper();
+            mapper.Entity<System.Index>().Ctor(document => new System.Index(
+                document["offset"].AsInt32,
+                document["fromEnd"].AsBoolean));
+            var stored = mapper.Serialize(typeof(object), System.Index.FromEnd(19)).AsDocument;
+
+            stored.Remove("Value");
+            stored.Remove("IsFromEnd");
+            stored["offset"] = 19;
+            stored["fromEnd"] = true;
+
+            var result = mapper.Deserialize(typeof(object), stored);
+
+            Assert.Equal(System.Index.FromEnd(19), Assert.IsType<System.Index>(result));
+        }
+
+        [Fact]
         public void A_User_Type_Merely_Named_System_Index_Should_Map_Normally()
         {
             var mapper = new BsonMapper();

--- a/LiteDB.Tests/Issues/Issue1929_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1929_Tests.cs
@@ -1,6 +1,8 @@
 #if !NETFRAMEWORK
 using System;
 using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace LiteDB.Tests.Issues
@@ -51,6 +53,89 @@ namespace LiteDB.Tests.Issues
 
             var index = Assert.IsType<System.Index>(result);
             Assert.Equal(expected, index);
+        }
+
+        [Fact]
+        public void Deserialize_Should_Honor_A_Custom_Constructor_For_System_Index()
+        {
+            var mapper = new BsonMapper();
+            mapper.Entity<System.Index>().Ctor(document => new System.Index(
+                document["offset"].AsInt32,
+                document["fromEnd"].AsBoolean));
+            var stored = new BsonDocument
+            {
+                ["offset"] = 17,
+                ["fromEnd"] = true
+            };
+
+            var result = mapper.Deserialize<System.Index>(stored);
+
+            Assert.Equal(System.Index.FromEnd(17), result);
+        }
+
+        [Fact]
+        public void A_User_Type_Merely_Named_System_Index_Should_Map_Normally()
+        {
+            var mapper = new BsonMapper();
+            var userType = CreateUnrelatedSystemIndexType();
+            var stored = new BsonDocument
+            {
+                ["Value"] = 12,
+                ["IsFromEnd"] = true
+            };
+
+            // This is not the BCL's System.Index. It only has the same full
+            // name, which must not activate LiteDB's special-case converter.
+            var result = mapper.Deserialize(userType, stored);
+
+            Assert.Equal(userType, result.GetType());
+            Assert.Equal(12, userType.GetProperty("Value").GetValue(result));
+            Assert.Equal(true, userType.GetProperty("IsFromEnd").GetValue(result));
+        }
+
+        private static Type CreateUnrelatedSystemIndexType()
+        {
+            var assembly = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName("Issue1929UserTypes_" + Guid.NewGuid().ToString("N")),
+                AssemblyBuilderAccess.Run);
+            var module = assembly.DefineDynamicModule("UserTypes");
+            var type = module.DefineType(
+                "System.Index",
+                TypeAttributes.Public | TypeAttributes.Class);
+
+            type.DefineDefaultConstructor(MethodAttributes.Public);
+            DefineAutoProperty(type, "Value", typeof(int));
+            DefineAutoProperty(type, "IsFromEnd", typeof(bool));
+
+            return type.CreateTypeInfo().AsType();
+        }
+
+        private static void DefineAutoProperty(TypeBuilder type, string name, Type propertyType)
+        {
+            var field = type.DefineField("_" + name, propertyType, FieldAttributes.Private);
+            var property = type.DefineProperty(name, PropertyAttributes.None, propertyType, null);
+            var getter = type.DefineMethod(
+                "get_" + name,
+                MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+                propertyType,
+                Type.EmptyTypes);
+            var getterIl = getter.GetILGenerator();
+            getterIl.Emit(OpCodes.Ldarg_0);
+            getterIl.Emit(OpCodes.Ldfld, field);
+            getterIl.Emit(OpCodes.Ret);
+            var setter = type.DefineMethod(
+                "set_" + name,
+                MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+                typeof(void),
+                new[] { propertyType });
+            var setterIl = setter.GetILGenerator();
+            setterIl.Emit(OpCodes.Ldarg_0);
+            setterIl.Emit(OpCodes.Ldarg_1);
+            setterIl.Emit(OpCodes.Stfld, field);
+            setterIl.Emit(OpCodes.Ret);
+
+            property.SetGetMethod(getter);
+            property.SetSetMethod(setter);
         }
 
         public class Person

--- a/LiteDB.Tests/Issues/Issue1929_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1929_Tests.cs
@@ -27,6 +27,32 @@ namespace LiteDB.Tests.Issues
             Assert.Equal(person.Selection, result.Selection);
         }
 
+        [Fact]
+        public void Deserialize_Should_Handle_System_Index_With_Object_Type_Discriminator()
+        {
+            var mapper = new BsonMapper();
+            var expected = System.Index.FromEnd(3);
+
+            var value = mapper.Serialize(typeof(object), expected);
+            var result = mapper.Deserialize(typeof(object), value);
+
+            var index = Assert.IsType<System.Index>(result);
+            Assert.Equal(expected, index);
+        }
+
+        [Fact]
+        public void Deserialize_Should_Handle_System_Index_With_Lower_Case_Delimiter()
+        {
+            var mapper = new BsonMapper().UseLowerCaseDelimiter();
+            var expected = System.Index.FromEnd(4);
+
+            var value = mapper.Serialize(expected);
+            var result = mapper.Deserialize(typeof(System.Index), value);
+
+            var index = Assert.IsType<System.Index>(result);
+            Assert.Equal(expected, index);
+        }
+
         public class Person
         {
             public string Id { get; set; } = Guid.NewGuid().ToString();

--- a/LiteDB.Tests/Issues/Issue1929_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1929_Tests.cs
@@ -1,0 +1,40 @@
+#if !NETFRAMEWORK
+using System;
+using System.IO;
+using Xunit;
+
+namespace LiteDB.Tests.Issues
+{
+    public class Issue1929_Tests
+    {
+        [Fact]
+        public void FindById_Should_Deserialize_System_Index_Property()
+        {
+            using var db = new LiteDatabase(new MemoryStream());
+            var collection = db.GetCollection<Person>("people");
+            var person = new Person
+            {
+                Name = "Alex",
+                Selection = System.Index.FromEnd(2)
+            };
+
+            collection.Insert(person);
+
+            var result = collection.FindById(person.Id);
+
+            Assert.NotNull(result);
+            Assert.Equal(person.Name, result.Name);
+            Assert.Equal(person.Selection, result.Selection);
+        }
+
+        public class Person
+        {
+            public string Id { get; set; } = Guid.NewGuid().ToString();
+
+            public string Name { get; set; }
+
+            public System.Index Selection { get; set; }
+        }
+    }
+}
+#endif

--- a/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
@@ -135,6 +135,10 @@ namespace LiteDB
             {
                 return value.AsArray;
             }
+            else if (type.FullName == "System.Index" && value.IsDocument)
+            {
+                return DeserializeSystemIndex(type, value.AsDocument);
+            }
 
             // raw values to native bson values
             else if (_bsonTypes.Contains(type))
@@ -286,6 +290,14 @@ namespace LiteDB
             }
 
             return enumerable;
+        }
+
+        private static object DeserializeSystemIndex(Type type, BsonDocument value)
+        {
+            return Activator.CreateInstance(
+                type,
+                value["Value"].AsInt32,
+                value["IsFromEnd"].AsBoolean);
         }
 
         private void DeserializeDictionary(Type keyType, Type valueType, IDictionary dict, BsonDocument value)

--- a/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
@@ -216,6 +216,11 @@ namespace LiteDB
                     type = typeof(Dictionary<string, object>);
                 }
 
+                if (type.FullName == "System.Index")
+                {
+                    return DeserializeSystemIndex(type, doc);
+                }
+
                 var entity = this.GetEntityMapper(type);
                 entity.WaitForInitialization();
 
@@ -292,12 +297,24 @@ namespace LiteDB
             return enumerable;
         }
 
-        private static object DeserializeSystemIndex(Type type, BsonDocument value)
+        private object DeserializeSystemIndex(Type type, BsonDocument value)
         {
             return Activator.CreateInstance(
                 type,
-                value["Value"].AsInt32,
-                value["IsFromEnd"].AsBoolean);
+                GetSystemIndexField(value, "Value").AsInt32,
+                GetSystemIndexField(value, "IsFromEnd").AsBoolean);
+        }
+
+        private BsonValue GetSystemIndexField(BsonDocument value, string fieldName)
+        {
+            var resolvedFieldName = this.ResolveFieldName(fieldName);
+
+            if (value.TryGetValue(resolvedFieldName, out var resolvedValue))
+            {
+                return resolvedValue;
+            }
+
+            return value[fieldName];
         }
 
         private void DeserializeDictionary(Type keyType, Type valueType, IDictionary dict, BsonDocument value)

--- a/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.Deserialize.cs
@@ -135,11 +135,6 @@ namespace LiteDB
             {
                 return value.AsArray;
             }
-            else if (type.FullName == "System.Index" && value.IsDocument)
-            {
-                return DeserializeSystemIndex(type, value.AsDocument);
-            }
-
             // raw values to native bson values
             else if (_bsonTypes.Contains(type))
             {
@@ -216,21 +211,27 @@ namespace LiteDB
                     type = typeof(Dictionary<string, object>);
                 }
 
-                if (type.FullName == "System.Index")
+                var entity = this.GetEntityMapper(type);
+                entity.WaitForInitialization();
+
+                object instance = _typeInstantiator(type);
+
+                if (instance == null && entity.CreateInstance != null)
+                {
+                    instance = entity.CreateInstance(doc);
+                }
+
+                if (instance == null && IsSystemIndexType(type))
                 {
                     return DeserializeSystemIndex(type, doc);
                 }
-
-                var entity = this.GetEntityMapper(type);
-                entity.WaitForInitialization();
 
                 // initialize CreateInstance
                 entity.CreateInstance = entity.CreateInstance
                     ?? GetTypeCtor(entity) 
                     ?? ((BsonDocument _) => Reflection.CreateInstance(entity.ForType));
 
-                object instance = _typeInstantiator(type) 
-                    ?? entity.CreateInstance(doc);
+                instance ??= entity.CreateInstance(doc);
 
                 if (instance is IDictionary dict)
                 {
@@ -303,6 +304,13 @@ namespace LiteDB
                 type,
                 GetSystemIndexField(value, "Value").AsInt32,
                 GetSystemIndexField(value, "IsFromEnd").AsBoolean);
+        }
+
+        private static bool IsSystemIndexType(Type type)
+        {
+            return type.FullName == "System.Index" &&
+                type.GetTypeInfo().IsValueType &&
+                type.Assembly == typeof(object).Assembly;
         }
 
         private BsonValue GetSystemIndexField(BsonDocument value, string fieldName)


### PR DESCRIPTION
Fixes #1929.

## Summary
- Reconstructs `System.Index` from the existing BSON document shape produced by the mapper: `{ Value, IsFromEnd }`.
- Fixes deserialization returning the default `Index` value for persisted `System.Index` properties.
- Uses reflection by type name so `netstandard2.0` builds do not take a compile-time dependency on `System.Index`.

## TDD / verification
- Added net8-only Issue1929 regression coverage for a typed collection containing a `System.Index` property.
- Verified targeted issue tests, mapper tests, `netstandard2.0` library build, and the full `net8.0` test project.

## Compatibility note
No on-disk format change. The fix reads the shape already written by the mapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deserialization of persisted `System.Index` values.
  * Improved compatibility with different field casing and document representations.
  * Correctly restores index values, including from-end indexes.
  * Prevented unrelated types with the same name from being incorrectly treated as `System.Index`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->