### PR TITLE
Fix #1759: alignment-safe ToBytes for Int64/UInt64 (SIGBUS/BUS_ADRALN on 32-bit ARM)

### DIFF
--- a/LiteDB.Tests/Issues/Issue1759_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1759_Tests.cs
@@ -1,65 +1,90 @@
 using System;
 using FluentAssertions;
-using LiteDB;
 using Xunit;
 
 namespace LiteDB.Tests.Issues
 {
     /// <summary>
-    /// #1759 - BufferExtensions.ToBytes(Int64/UInt64/Double) used an unaligned
-    /// *(long*)ptr = value store. On 32-bit ARM (armeabi-v7a) this crashes with
-    /// SIGBUS / BUS_ADRALN under IL2CPP or Mono-LLVM Release, because the compiler
-    /// emits STRD/STM which require a word-aligned address. The write must be
-    /// alignment-safe (byte-wise).
+    /// #1759 - ToBytes(Int64/UInt64/Double) stored 8 bytes through a single
+    /// `*(long*)ptr = value` write. On 32-bit ARM (armeabi-v7a) that is lowered to
+    /// STRD/STM, which fault with SIGBUS/BUS_ADRALN when the destination is not
+    /// word-aligned, so writing e.g. the LIMIT_SIZE pragma (page offset 101) killed
+    /// the process. The store is now done byte by byte, which has no alignment
+    /// requirement.
     ///
-    /// The alignment fault itself cannot be observed on x86/x64 CI (those tolerate
-    /// unaligned access), so these tests assert byte-level correctness at unaligned
-    /// offsets to guard against a regression to the pointer-cast implementation.
+    /// The alignment fault itself cannot be observed on x86/x64 (unaligned access is
+    /// allowed there), so these tests pin down the two properties that must hold on
+    /// every platform: the bytes stay in the platform's native order, and the value
+    /// survives a write/read round trip through the buffer at unaligned offsets.
     /// </summary>
     public class Issue1759_Tests
     {
+        public static TheoryData<int> UnalignedOffsets => new TheoryData<int> { 0, 1, 2, 3, 5, 7 };
+
         [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(3)]
-        public void ToBytes_Int64_is_correct_at_unaligned_offset(int offset)
+        [MemberData(nameof(UnalignedOffsets))]
+        public void ToBytes_Int64_keeps_native_byte_order(int offset)
         {
-            var value = long.MaxValue; // 0x7FFFFFFFFFFFFFFF - the value seen in real crashes
-            var buffer = new byte[offset + 8];
+            foreach (var value in new[] { long.MaxValue, long.MinValue, -1L, 1L, 0x0102030405060708L })
+            {
+                var buffer = new byte[offset + 8];
 
-            value.ToBytes(buffer, offset);
+                value.ToBytes(buffer, offset);
 
-            BitConverter.ToInt64(buffer, offset).Should().Be(value);
+                // BitConverter is native-endian, and so are the matching readers, so the
+                // bytes written must be byte-for-byte what BitConverter produces.
+                buffer.AsSpan(offset, 8).ToArray()
+                    .Should().Equal(BitConverter.GetBytes(value), "value {0} at offset {1}", value, offset);
+            }
         }
 
         [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(3)]
-        public void ToBytes_UInt64_is_correct_at_unaligned_offset(int offset)
+        [MemberData(nameof(UnalignedOffsets))]
+        public void ToBytes_UInt64_keeps_native_byte_order(int offset)
         {
-            var value = ulong.MaxValue - 12345UL;
-            var buffer = new byte[offset + 8];
+            foreach (var value in new[] { ulong.MaxValue, ulong.MinValue, 1UL, 0x0102030405060708UL })
+            {
+                var buffer = new byte[offset + 8];
 
-            value.ToBytes(buffer, offset);
+                value.ToBytes(buffer, offset);
 
-            BitConverter.ToUInt64(buffer, offset).Should().Be(value);
+                buffer.AsSpan(offset, 8).ToArray()
+                    .Should().Equal(BitConverter.GetBytes(value), "value {0} at offset {1}", value, offset);
+            }
         }
 
         [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(3)]
-        public void ToBytes_Double_is_correct_at_unaligned_offset(int offset)
+        [MemberData(nameof(UnalignedOffsets))]
+        public void ToBytes_Double_keeps_native_byte_order(int offset)
         {
-            var value = Math.PI;
-            var buffer = new byte[offset + 8];
+            foreach (var value in new[] { Math.PI, 0d, -1.5d, double.MaxValue, double.MinValue })
+            {
+                var buffer = new byte[offset + 8];
 
-            value.ToBytes(buffer, offset);
+                value.ToBytes(buffer, offset);
 
-            BitConverter.ToDouble(buffer, offset).Should().Be(value);
+                buffer.AsSpan(offset, 8).ToArray()
+                    .Should().Equal(BitConverter.GetBytes(value), "value {0} at offset {1}", value, offset);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(UnalignedOffsets))]
+        public void BufferSlice_write_read_round_trips_at_unaligned_offset(int offset)
+        {
+            // Exercises the real writer + reader pair, so it fails on any platform where
+            // the two disagree about byte order - not just on little-endian hosts.
+            var slice = new BufferSlice(new byte[offset + 8 + 8], offset, 16);
+
+            slice.Write(long.MaxValue, 1);
+            slice.ReadInt64(1).Should().Be(long.MaxValue);
+
+            slice.Write(Math.PI, 1);
+            slice.ReadDouble(1).Should().Be(Math.PI);
+
+            var utcNow = DateTime.UtcNow;
+            slice.Write(utcNow, 1);
+            slice.ReadDateTime(1).Should().BeCloseTo(utcNow, TimeSpan.FromMilliseconds(1));
         }
     }
 }

--- a/LiteDB.Tests/Issues/Issue1759_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1759_Tests.cs
@@ -1,0 +1,65 @@
+using System;
+using FluentAssertions;
+using LiteDB;
+using Xunit;
+
+namespace LiteDB.Tests.Issues
+{
+    /// <summary>
+    /// #1759 - BufferExtensions.ToBytes(Int64/UInt64/Double) used an unaligned
+    /// *(long*)ptr = value store. On 32-bit ARM (armeabi-v7a) this crashes with
+    /// SIGBUS / BUS_ADRALN under IL2CPP or Mono-LLVM Release, because the compiler
+    /// emits STRD/STM which require a word-aligned address. The write must be
+    /// alignment-safe (byte-wise).
+    ///
+    /// The alignment fault itself cannot be observed on x86/x64 CI (those tolerate
+    /// unaligned access), so these tests assert byte-level correctness at unaligned
+    /// offsets to guard against a regression to the pointer-cast implementation.
+    /// </summary>
+    public class Issue1759_Tests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void ToBytes_Int64_is_correct_at_unaligned_offset(int offset)
+        {
+            var value = long.MaxValue; // 0x7FFFFFFFFFFFFFFF - the value seen in real crashes
+            var buffer = new byte[offset + 8];
+
+            value.ToBytes(buffer, offset);
+
+            BitConverter.ToInt64(buffer, offset).Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void ToBytes_UInt64_is_correct_at_unaligned_offset(int offset)
+        {
+            var value = ulong.MaxValue - 12345UL;
+            var buffer = new byte[offset + 8];
+
+            value.ToBytes(buffer, offset);
+
+            BitConverter.ToUInt64(buffer, offset).Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(3)]
+        public void ToBytes_Double_is_correct_at_unaligned_offset(int offset)
+        {
+            var value = Math.PI;
+            var buffer = new byte[offset + 8];
+
+            value.ToBytes(buffer, offset);
+
+            BitConverter.ToDouble(buffer, offset).Should().Be(value);
+        }
+    }
+}

--- a/LiteDB/Utils/Extensions/BufferExtensions.cs
+++ b/LiteDB/Utils/Extensions/BufferExtensions.cs
@@ -115,12 +115,20 @@ namespace LiteDB
         /// <summary>
         /// Copy Int64 bytes direct into buffer
         /// </summary>
-        public static unsafe void ToBytes(this Int64 value, byte[] array, int startIndex)
+        public static void ToBytes(this Int64 value, byte[] array, int startIndex)
         {
-            fixed (byte* ptr = &array[startIndex])
-            {
-                *(Int64*)ptr = value;
-            }
+            // NOTE (ARMv7/armeabi-v7a fix): the original code did *(Int64*)ptr = value,
+            // an unaligned 8-byte store. On 32-bit ARM the JIT/AOT (esp. Mono LLVM) emits
+            // STRD/STM which fault (SIGBUS/BUS_ADRALN) on non-word-aligned addresses.
+            // Byte-wise little-endian write is alignment-safe on every architecture.
+            array[startIndex]     = (byte)value;
+            array[startIndex + 1] = (byte)(value >> 8);
+            array[startIndex + 2] = (byte)(value >> 16);
+            array[startIndex + 3] = (byte)(value >> 24);
+            array[startIndex + 4] = (byte)(value >> 32);
+            array[startIndex + 5] = (byte)(value >> 40);
+            array[startIndex + 6] = (byte)(value >> 48);
+            array[startIndex + 7] = (byte)(value >> 56);
         }
 
         /// <summary>
@@ -148,12 +156,18 @@ namespace LiteDB
         /// <summary>
         /// Copy Int64 bytes direct into buffer
         /// </summary>
-        public static unsafe void ToBytes(this UInt64 value, byte[] array, int startIndex)
+        public static void ToBytes(this UInt64 value, byte[] array, int startIndex)
         {
-            fixed (byte* ptr = &array[startIndex])
-            {
-                *(UInt64*)ptr = value;
-            }
+            // ARMv7 alignment-safe write (see Int64 overload above). Double.ToBytes
+            // routes through this method, so this also fixes 8-byte double writes.
+            array[startIndex]     = (byte)value;
+            array[startIndex + 1] = (byte)(value >> 8);
+            array[startIndex + 2] = (byte)(value >> 16);
+            array[startIndex + 3] = (byte)(value >> 24);
+            array[startIndex + 4] = (byte)(value >> 32);
+            array[startIndex + 5] = (byte)(value >> 40);
+            array[startIndex + 6] = (byte)(value >> 48);
+            array[startIndex + 7] = (byte)(value >> 56);
         }
 
         /// <summary>

--- a/LiteDB/Utils/Extensions/BufferExtensions.cs
+++ b/LiteDB/Utils/Extensions/BufferExtensions.cs
@@ -117,18 +117,10 @@ namespace LiteDB
         /// </summary>
         public static void ToBytes(this Int64 value, byte[] array, int startIndex)
         {
-            // NOTE (ARMv7/armeabi-v7a fix): the original code did *(Int64*)ptr = value,
-            // an unaligned 8-byte store. On 32-bit ARM the JIT/AOT (esp. Mono LLVM) emits
-            // STRD/STM which fault (SIGBUS/BUS_ADRALN) on non-word-aligned addresses.
-            // Byte-wise little-endian write is alignment-safe on every architecture.
-            array[startIndex]     = (byte)value;
-            array[startIndex + 1] = (byte)(value >> 8);
-            array[startIndex + 2] = (byte)(value >> 16);
-            array[startIndex + 3] = (byte)(value >> 24);
-            array[startIndex + 4] = (byte)(value >> 32);
-            array[startIndex + 5] = (byte)(value >> 40);
-            array[startIndex + 6] = (byte)(value >> 48);
-            array[startIndex + 7] = (byte)(value >> 56);
+            unchecked
+            {
+                ToBytes((UInt64)value, array, startIndex);
+            }
         }
 
         /// <summary>
@@ -158,16 +150,39 @@ namespace LiteDB
         /// </summary>
         public static void ToBytes(this UInt64 value, byte[] array, int startIndex)
         {
-            // ARMv7 alignment-safe write (see Int64 overload above). Double.ToBytes
-            // routes through this method, so this also fixes 8-byte double writes.
-            array[startIndex]     = (byte)value;
-            array[startIndex + 1] = (byte)(value >> 8);
-            array[startIndex + 2] = (byte)(value >> 16);
-            array[startIndex + 3] = (byte)(value >> 24);
-            array[startIndex + 4] = (byte)(value >> 32);
-            array[startIndex + 5] = (byte)(value >> 40);
-            array[startIndex + 6] = (byte)(value >> 48);
-            array[startIndex + 7] = (byte)(value >> 56);
+            // A single `*(UInt64*)ptr = value` store is lowered to STRD/STM on 32-bit ARM,
+            // which fault with SIGBUS/BUS_ADRALN when the destination is not word-aligned
+            // (see #1759). Byte stores have no alignment requirement.
+            //
+            // The byte order follows the running platform, so the bytes written here are
+            // identical to the ones the previous pointer store produced. That keeps the
+            // on-disk layout unchanged: the matching readers (ReadInt64/ReadUInt64/
+            // ReadDouble) use BitConverter, which is also native-endian.
+            unchecked
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    array[startIndex] = (byte)value;
+                    array[startIndex + 1] = (byte)(value >> 8);
+                    array[startIndex + 2] = (byte)(value >> 16);
+                    array[startIndex + 3] = (byte)(value >> 24);
+                    array[startIndex + 4] = (byte)(value >> 32);
+                    array[startIndex + 5] = (byte)(value >> 40);
+                    array[startIndex + 6] = (byte)(value >> 48);
+                    array[startIndex + 7] = (byte)(value >> 56);
+                }
+                else
+                {
+                    array[startIndex] = (byte)(value >> 56);
+                    array[startIndex + 1] = (byte)(value >> 48);
+                    array[startIndex + 2] = (byte)(value >> 40);
+                    array[startIndex + 3] = (byte)(value >> 32);
+                    array[startIndex + 4] = (byte)(value >> 24);
+                    array[startIndex + 5] = (byte)(value >> 16);
+                    array[startIndex + 6] = (byte)(value >> 8);
+                    array[startIndex + 7] = (byte)value;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1759.

## Problem
`BufferExtensions.ToBytes(Int64/UInt64)` wrote 8 bytes through a single pointer store:

```csharp
public static unsafe void ToBytes(this Int64 value, byte[] array, int startIndex)
{
    fixed (byte* ptr = &array[startIndex]) { *(Int64*)ptr = value; }
}
```

On 32-bit ARM (`armeabi-v7a`) that store is lowered to `STRD`/`STM`, which require a
word-aligned address. When `startIndex` is not word-aligned the CPU raises an alignment
fault — **`SIGBUS`, code `BUS_ADRALN`** — and the process dies. Reported with Unity
IL2CPP; also reproduced with .NET for Android using Mono LLVM AOT
(`RunAOTCompilation` + `EnableLLVM`).

It is not an edge case. `EnginePragmas.UpdateBuffer` writes the `LIMIT_SIZE` pragma
(default `long.MaxValue`) at the fixed page offset `P_LIMIT_SIZE = 101`; because
`101 % 4 == 1` the destination is always unaligned, so every header-page flush crashes.

## Fix
The 8-byte stores are done byte by byte, which has no alignment requirement:

- **Byte order follows the platform** (`BitConverter.IsLittleEndian`), so the bytes are
  identical to what the pointer store produced. The on-disk layout is unchanged, which
  matters because the matching readers (`ReadInt64`/`ReadUInt64`/`ReadDouble`) use
  native-endian `BitConverter`.
- The stores run inside `unchecked`, so the narrowing casts behave like the removed
  pointer store even when the library is compiled with `CheckForOverflowUnderflow=true`.
- `Int64` delegates to the `UInt64` overload; `Double` already routed through `UInt64`.
- The 16/32-bit overloads are left alone: single-word `STR`/`STRH` tolerate unaligned
  access on ARMv7, only the 8-byte `STRD`/`STM` path faults.

No new dependencies.

## Tests
`LiteDB.Tests/Issues/Issue1759_Tests.cs` pins down the two properties that must hold on
every platform, at unaligned offsets (0, 1, 2, 3, 5, 7):

- the written bytes equal `BitConverter.GetBytes(value)` (native order), and
- a write/read round trip through `BufferSlice` returns the original value
  (`Int64`, `Double`, `DateTime`).

The round-trip test is architecture-independent: it fails on any platform where writer
and reader disagree about byte order, not just on little-endian hosts. The alignment
fault itself cannot be observed on x86/x64, since unaligned access is allowed there.

## Verification
- Full suite on `net8.0`: 299 passed / 6 skipped, no regressions (baseline `dev`: 275/6,
  plus the 24 new cases here).
- Same suite with `-p:CheckForOverflowUnderflow=true`: all green; the IL for
  `ToBytes(UInt64)` contains no `conv.ovf` while the rest of the assembly does, so the
  `unchecked` block is doing its job in a genuinely checked build.
- On-disk compatibility: a database written by `dev` is read back by this branch with all
  values intact (`long`, `ulong`, `double`, `DateTime`), and vice versa.
- Machine code, `android-arm` + AOT + LLVM: in a build of unpatched `dev` the pattern
  "array element address → 8-byte multi-word store" appears 8 times in
  `libaot-LiteDB.dll.so`, including `stmne r1, {r0, r3}` directly after
  `add r1, r1, #101` (the `LIMIT_SIZE` write). With this patch that pattern is gone
  (0 occurrences) — the byte stores are not merged back into `STRD`/`STM`.
- On a physical 32-bit ARM device, the earlier byte-wise version of this patch turned a
  reproducible `SIGBUS/BUS_ADRALN` on the first header flush into a clean run with LLVM
  AOT still enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 64-bit integer and floating-point serialization at unaligned buffer offsets.
  * Prevented potential failures on platforms sensitive to unaligned memory access.
  * Preserved native byte-order behavior across supported platforms.

* **Tests**
  * Added coverage across multiple offsets for `Int64`, `UInt64`, and `Double`.
  * Added round-trip validation for 64-bit integers, floating-point values, and dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->