### PR TITLE
Fix formatted ENSURE error messages

### DIFF
--- a/LiteDB.Tests/Utils/Constants_Tests.cs
+++ b/LiteDB.Tests/Utils/Constants_Tests.cs
@@ -1,0 +1,18 @@
+using FluentAssertions;
+using Xunit;
+
+namespace LiteDB.Tests.Utils
+{
+    public class Constants_Tests
+    {
+        [Fact]
+        public void Ensure_Formats_Message()
+        {
+            var exception = Assert.Throws<LiteException>(() =>
+                Constants.ENSURE(false, "value {0} / {1}", 7, "x"));
+
+            exception.ErrorCode.Should().Be(LiteException.INVALID_DATAFILE_STATE);
+            exception.Message.Should().Be("value 7 / x");
+        }
+    }
+}

--- a/LiteDB/Utils/Constants.cs
+++ b/LiteDB/Utils/Constants.cs
@@ -159,7 +159,7 @@ namespace LiteDB
 
                 var message = string.Format(CultureInfo.InvariantCulture, format, args);
 
-                throw LiteException.InvalidDatafileState(format);
+                throw LiteException.InvalidDatafileState(message);
             }
         }
 


### PR DESCRIPTION
`Constants.ENSURE(bool, string, params object[])` now passes its formatted message to `InvalidDatafileState`, so diagnostics contain the failing page, index, or value instead of literal placeholders such as `{0}`.

A focused regression test covers multiple arguments and verifies both the error code and final message.

Fixes #2840.

Validation:
- `dotnet test LiteDB.Tests/LiteDB.Tests.csproj -f net8.0 --filter FullyQualifiedName~Constants_Tests` (1 passed)
- `dotnet test LiteDB.Tests/LiteDB.Tests.csproj -f net8.0 --no-restore --no-build` (346 passed, 7 skipped)
- `dotnet format LiteDB.sln whitespace --no-restore --verify-no-changes --include LiteDB/Utils/Constants.cs LiteDB.Tests/Utils/Constants_Tests.cs`
